### PR TITLE
remove field signature type when mixed

### DIFF
--- a/app/views/decidim/initiatives/create_initiative/fill_data.html.erb
+++ b/app/views/decidim/initiatives/create_initiative/fill_data.html.erb
@@ -1,0 +1,95 @@
+<% content_for :back_link do %>
+  <%= link_to :back do %>
+    <%= icon "chevron-left", class: "icon--small", role: "img", "aria-hidden": true %>
+    <%= t(".back") %>
+  <% end %>
+<% end %>
+
+<div class="row column">
+  <div class="medium-centered">
+    <div class="callout secondary">
+      <%== t ".fill_data_help" %>
+      <%= link_to t(".more_information"), decidim.page_path("initiatives"), target: "_blank" %>.
+    </div>
+  </div>
+</div>
+<br>
+<div class="row">
+  <div class="medium-centered">
+    <div class="card">
+      <div class="card__content">
+        <%= decidim_form_for(@form, url: next_wizard_path, method: :put, html: { class: "form new_initiative_form" }) do |f| %>
+          <%= form_required_explanation %>
+          <%= f.hidden_field :type_id %>
+          <div class=section>
+            <% unless single_initiative_type? %>
+              <div class="field">
+                <label for="type_description"><%= t ".initiative_type" %></label>
+                <%= text_field_tag :type_description, strip_tags(translated_attribute(initiative_type.title)), readonly: true %>
+              </div>
+            <% end %>
+
+            <div class="field">
+              <%= f.text_field :title, autofocus: true %>
+            </div>
+
+            <div class="field">
+              <%= f.editor :description, lines: 8, toolbar: :full %>
+            </div>
+
+            <% signature_type_options = signature_type_options(f.object) %>
+            <% if signature_type_options.length == 1 %>
+              <%= f.hidden_field :signature_type, value: signature_type_options.first.last %>
+            <% else %>
+              <%= f.hidden_field :signature_type, value: signature_type_options.last.last %>
+          <% end %>
+
+            <% if scopes.length == 1 %>
+              <%= f.hidden_field :scope_id, value: scopes.first.scope&.id %>
+            <% else %>
+              <div class="field">
+                <%= f.select :scope_id,
+                             scopes.map { |scope| [translated_attribute(scope.scope_name), scope&.scope&.id] },
+                             required: true,
+                             include_blank: t(".select_scope") %>
+              </div>
+            <% end %>
+
+            <% if initiative_type.custom_signature_end_date_enabled? %>
+              <div class="field">
+                <%= f.date_field :signature_end_date %>
+              </div>
+            <% end %>
+
+            <% if initiative_type.area_enabled? %>
+              <div class="field">
+                <%= f.areas_select :area_id, areas_for_select(current_organization), prompt: t(".select_area") %>
+              </div>
+            <% end %>
+
+            <% if Decidim::UserGroups::ManageableUserGroups.for(current_user).verified.any? %>
+              <div class="field">
+                <%= f.select :decidim_user_group_id,
+                             Decidim::UserGroups::ManageableUserGroups.for(current_user).verified.map { |g| [g.name, g.id] },
+                             include_blank: current_user.name %>
+              </div>
+            <% end %>
+
+            <% if initiative_type.attachments_enabled? %>
+              <fieldset class="attachments_container">
+                <legend><%= t("attachment_legend", scope: "decidim.initiatives.form") %></legend>
+
+                <div class="row column">
+                  <%= f.file_field :add_documents, multiple: true, label: t("add_attachments", scope: "decidim.initiatives.form") %>
+                </div>
+              </fieldset>
+            <% end %>
+          </div>
+          <div class="actions">
+            <%= f.submit t(".continue"), class: "button expanded", data: { disable_with: true } %>
+          </div>
+        <% end %>
+      </div>
+    </div>
+  </div>
+</div>

--- a/spec/system/create_initiative_spec.rb
+++ b/spec/system/create_initiative_spec.rb
@@ -337,6 +337,15 @@ describe "Initiative", type: :system do
             end
           end
 
+          context "when mixed signature collection are available" do
+            let(:initiative_type) { create(:initiatives_type, organization: organization, minimum_committee_members: initiative_type_minimum_committee_members, signature_type: "any") }
+
+            it "hides and automatically selects the values" do
+              expect(page).not_to have_content("Signature collection type")
+              expect(find(:xpath, "//input[@id='initiative_signature_type']", visible: :all).value).to eq("any")
+            end
+          end
+
           context "when the scope isn't selected" do
             it "shows an error" do
               select("Online", from: "Signature collection type")


### PR DESCRIPTION
when an initiative type is configured to accept mixed signatures, it automatically configure the initiatives to accept it
Consequently, the signature type field is never asked when a signature type is defined in the initiative type.