### PR TITLE
[Task] - socio demographic metadata

### DIFF
--- a/app/commands/decidim/verifications/authorize_user.rb
+++ b/app/commands/decidim/verifications/authorize_user.rb
@@ -7,10 +7,12 @@ module Decidim
       # Public: Initializes the command.
       #
       # handler - An AuthorizationHandler object.
+      # rubocop:disable Lint/MissingSuper
       def initialize(handler, organization)
         @handler = handler
         @organization = organization
       end
+      # rubocop:enable Lint/MissingSuper
 
       # Executes the command. Broadcasts these events:
       #
@@ -60,6 +62,8 @@ module Decidim
       end
 
       def duplicates_metadata_in_user!(handler)
+        return unless handler.is_a? Decidim::ExtendedSocioDemographicAuthorizationHandler
+
         handler_extended_data = handler.metadata.deep_transform_keys { |k| "socio_#{k}" }
         handler.user.update!(extended_data: handler_extended_data)
       end

--- a/app/commands/decidim/verifications/authorize_user.rb
+++ b/app/commands/decidim/verifications/authorize_user.rb
@@ -62,7 +62,7 @@ module Decidim
       end
 
       def duplicates_metadata_in_user!(handler)
-        return unless handler.is_a? Decidim::ExtendedSocioDemographicAuthorizationHandler
+        return unless handler.class.name == "ExtendedSocioDemographicAuthorizationHandler"
 
         handler_extended_data = handler.metadata.deep_transform_keys { |k| "socio_#{k}" }
         handler.user.update!(extended_data: handler_extended_data)

--- a/app/commands/decidim/verifications/authorize_user.rb
+++ b/app/commands/decidim/verifications/authorize_user.rb
@@ -65,7 +65,7 @@ module Decidim
         return unless handler.class.name == "ExtendedSocioDemographicAuthorizationHandler"
 
         handler_extended_data = handler.metadata.deep_transform_keys { |k| "socio_#{k}" }
-        handler.user.update!(extended_data: handler_extended_data)
+        handler.user.update!(extended_data: handler.user.extended_data.merge(handler_extended_data))
       end
     end
   end

--- a/app/commands/decidim/verifications/authorize_user.rb
+++ b/app/commands/decidim/verifications/authorize_user.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Verifications
+    # A command to authorize a user with an authorization handler.
+    class AuthorizeUser < Rectify::Command
+      # Public: Initializes the command.
+      #
+      # handler - An AuthorizationHandler object.
+      def initialize(handler, organization)
+        @handler = handler
+        @organization = organization
+      end
+
+      # Executes the command. Broadcasts these events:
+      #
+      # - :ok when everything is valid.
+      # - :invalid if the handler wasn't valid and we couldn't proceed.
+      #
+      # Returns nothing.
+      def call
+        if handler.invalid?
+          conflict = create_verification_conflict
+          notify_admins(conflict) if conflict.present?
+
+          return broadcast(:invalid)
+        end
+
+        Authorization.create_or_update_from(handler)
+        duplicates_metadata_in_user!(handler)
+        broadcast(:ok)
+      end
+
+      private
+
+      attr_reader :handler
+
+      def notify_admins(conflict)
+        Decidim::EventsManager.publish(
+          event: "decidim.events.verifications.managed_user_error_event",
+          event_class: Decidim::Verifications::ManagedUserErrorEvent,
+          resource: conflict,
+          affected_users: Decidim::User.where(admin: true, organization: @organization)
+        )
+      end
+
+      def create_verification_conflict
+        authorization = Decidim::Authorization.find_by(unique_id: handler.unique_id)
+        return if authorization.blank?
+
+        conflict = Decidim::Verifications::Conflict.find_or_initialize_by(
+          current_user: handler.user,
+          managed_user: authorization.user,
+          unique_id: handler.unique_id
+        )
+
+        conflict.update(times: conflict.times + 1)
+
+        conflict
+      end
+
+      def duplicates_metadata_in_user!(handler)
+        handler_extended_data = handler.metadata.deep_transform_keys { |k| "socio_#{k}" }
+        handler.user.update!(extended_data: handler_extended_data)
+      end
+    end
+  end
+end

--- a/app/commands/decidim/verifications/destroy_user_authorization.rb
+++ b/app/commands/decidim/verifications/destroy_user_authorization.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Verifications
+    # A command to Destroy the Authorization of a user.
+    class DestroyUserAuthorization < Rectify::Command
+      def initialize(authorization)
+        @authorization = authorization
+      end
+
+      def call
+        return broadcast(:invalid) unless authorization
+
+        authorization.destroy!
+        remove_user_extended_data!(authorization)
+
+        broadcast(:ok, authorization)
+      end
+
+      private
+
+      def remove_user_extended_data!(auth)
+        return unless auth.name == "extended_socio_demographic_authorization_handler"
+
+        extended_data = auth.user.extended_data.reject { |key| key.start_with?("socio_") }
+        auth.user.update!(extended_data: extended_data)
+      end
+
+      attr_reader :authorization
+    end
+  end
+end

--- a/app/commands/decidim/verifications/destroy_user_authorization.rb
+++ b/app/commands/decidim/verifications/destroy_user_authorization.rb
@@ -4,9 +4,11 @@ module Decidim
   module Verifications
     # A command to Destroy the Authorization of a user.
     class DestroyUserAuthorization < Rectify::Command
+      # rubocop:disable Lint/MissingSuper
       def initialize(authorization)
         @authorization = authorization
       end
+      # rubocop:enable Lint/MissingSuper
 
       def call
         return broadcast(:invalid) unless authorization

--- a/app/commands/decidim/verifications/revoke_all_authorizations.rb
+++ b/app/commands/decidim/verifications/revoke_all_authorizations.rb
@@ -8,10 +8,12 @@ module Decidim
       #
       # organization - Organization object.
       # current_user - The current user.
+      # rubocop:disable Lint/MissingSuper
       def initialize(organization, current_user)
         @organization = organization
         @current_user = current_user
       end
+      # rubocop:enable Lint/MissingSuper
 
       # Executes the command. Broadcasts these events:
       #

--- a/app/commands/decidim/verifications/revoke_all_authorizations.rb
+++ b/app/commands/decidim/verifications/revoke_all_authorizations.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Verifications
+    # A command to revoke authorizations
+    class RevokeAllAuthorizations < Rectify::Command
+      # Public: Initializes the command.
+      #
+      # organization - Organization object.
+      # current_user - The current user.
+      def initialize(organization, current_user)
+        @organization = organization
+        @current_user = current_user
+      end
+
+      # Executes the command. Broadcasts these events:
+      #
+      # - :ok when everything is valid.
+      # - :invalid if the handler wasn't valid and we couldn't proceed.
+      #
+      # Returns nothing.
+      def call
+        return broadcast(:invalid) unless @organization
+
+        auths = Decidim::Verifications::Authorizations.new(
+          organization: organization,
+          granted: true
+        ).query
+
+        auths.find_each do |auth|
+          Decidim.traceability.perform_action!(
+            :destroy,
+            auth,
+            current_user
+          ) do
+            remove_user_extended_data!(auth)
+            auth.destroy
+          end
+        end
+
+        broadcast(:ok)
+      end
+
+      private
+
+      def remove_user_extended_data!(auth)
+        return unless auth.name == "extended_socio_demographic_authorization_handler"
+
+        extended_data = auth.user.extended_data.reject { |key| key.start_with?("socio_") }
+        auth.user.update!(extended_data: extended_data)
+      end
+
+      attr_reader :organization, :current_user
+    end
+  end
+end

--- a/config/initializers/decidim.rb
+++ b/config/initializers/decidim.rb
@@ -32,7 +32,6 @@ Decidim.configure do |config|
     static: { url: "https://image.maps.ls.hereapi.com/mia/1.6/mapview" }
   }
 
-
   # Custom resource reference generator method
   # config.resource_reference_generator = lambda do |resource, feature|
   #   # Implement your custom method to generate resources references

--- a/config/initializers/decidim.rb
+++ b/config/initializers/decidim.rb
@@ -26,6 +26,13 @@ Decidim.configure do |config|
     }
   end
 
+  config.maps = {
+    provider: :here,
+    api_key: Rails.application.secrets.maps[:api_key],
+    static: { url: "https://image.maps.ls.hereapi.com/mia/1.6/mapview" }
+  }
+
+
   # Custom resource reference generator method
   # config.resource_reference_generator = lambda do |resource, feature|
   #   # Implement your custom method to generate resources references

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -40,6 +40,8 @@ default: &default
       client_secret: <%= ENV["OMNIAUTH_GOOGLE_CLIENT_SECRET"] %>
   geocoder:
     here_api_key: <%= ENV["GEOCODER_LOOKUP_API_KEY"] %>
+  maps:
+    api_key: <%= ENV["GEOCODER_LOOKUP_API_KEY"] %>
   sentry:
     enabled: <%= !ENV["SENTRY_DSN"].blank? %>
     dsn: <%= ENV["SENTRY_DSN"] %>

--- a/lib/tasks/duplicates_metadata.rake
+++ b/lib/tasks/duplicates_metadata.rake
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+namespace :decidim do
+  namespace :repare do
+    desc "Check for nicknames that doesn't respect valid format and update them"
+    task nickname: :environment do
+      logger = Logger.new($stdout)
+      logger.info("[data:repare:nickname] :: Checking all nicknames...")
+      invalid_users = Decidim::User.where.not("nickname ~* ?", "^[\\w-]+$")
+
+      if invalid_users.blank?
+        logger.info("[data:repare:nickname] :: All nicknames seems to be valid")
+        logger.info("[data:repare:nickname] :: Operation terminated")
+        exit 0
+      end
+
+      logger.info("[data:repare:nickname] :: Found #{invalid_users.count} invalids nicknames")
+      logger.info("[data:repare:nickname] :: Invalid user IDs : [#{invalid_users.map(&:id).join(", ")}]")
+
+      updated_users = []
+      invalid_users.each do |user|
+        chars = []
+
+        user.nickname.codepoints.each do |ascii_code|
+          char = ascii_to_valid_char(ascii_code)
+          chars << char if char.present?
+        end
+
+        new_nickname = chars.join.downcase
+        logger.info("[data:repare:nickname] :: User (##{user.id}) renaming nickname from '#{user.nickname}' to '#{new_nickname}'")
+        user.nickname = new_nickname
+
+        updated_users << user
+      end
+
+      if ask_for_permission(updated_users.count)
+        logger.info("[data:repare:nickname] :: Updating users...")
+        updated_users.each do |user|
+          user.save!
+          logger.info("[data:repare:nickname] :: User (##{user.id}) successfully updated")
+        rescue StandardError => e
+          logger.error("[data:repare:nickname] :: User (##{user.id}) an error occured")
+          logger.error("[data:repare:nickname] :: #{e}")
+        end
+      else
+        logger.info("[data:repare:nickname] :: Operation terminated")
+      end
+      logger.close
+
+      exit 0
+    end
+  end
+end
+
+def ask_for_permission(users_count)
+  $stdout.puts "Do you want to update these #{users_count} users ? [y/n]"
+  answer = $stdin.gets.chomp
+
+  %w(y Y yes YES).include?(answer)
+end
+
+def ascii_to_valid_char(id)
+  letters = ("A".."Z").to_a.join("").codepoints
+  letters += ("a".."z").to_a.join("").codepoints
+  digits = ("0".."9").to_a.join("").codepoints
+  special_chars = %w(- _).join("").codepoints
+
+  valid_ascii_code = letters + digits + special_chars
+
+  valid_ascii_code.include?(id) ? id.chr : ""
+end

--- a/lib/tasks/duplicates_metadata.rake
+++ b/lib/tasks/duplicates_metadata.rake
@@ -11,28 +11,31 @@ namespace :decidim do
       updated = []
       authorizations.each do |auth|
         if auth.user.blank? || !auth.user.respond_to?(:extended_data)
-          logger.error(logger_output "Undefined user for authorization ID/#{auth.id}")
+          logger.error(logger_output("Undefined user for authorization ID/#{auth.id}"))
           next
         end
-        next if auth.user.extended_data.include?("socio_postal_code") || auth.user.extended_data.include?("socio_city") || auth.user.extended_data.include?("socio_email") || auth.user.extended_data.include?("socio_phone_number")
+        next if auth.user.extended_data.include?("socio_postal_code")
+        next if auth.user.extended_data.include?("socio_city")
+        next if auth.user.extended_data.include?("socio_email")
+        next if auth.user.extended_data.include?("socio_phone_number")
 
         extended_data = auth.metadata.deep_transform_keys { |key| "socio_#{key}" }
 
-        if auth.user.update_column(:extended_data, auth.user.extended_data.merge(extended_data))
-          logger.info(logger_output "Updating user (ID/#{auth.user.id})")
+        if auth.user.update(extended_data: auth.user.extended_data.merge(extended_data))
+          logger.info(logger_output("Updating user (ID/#{auth.user.id})"))
           updated << auth.user.id
         else
-          logger.error(logger_output "Errors happened while updating user (ID/#{auth.user.id})")
+          logger.error(logger_output("Errors happened while updating user (ID/#{auth.user.id})"))
         end
       end
-      logger.info(logger_output "Found #{authorizations.count} extended socio demographic authorizations")
-      logger.info(logger_output "Updated #{updated.count} users : #{updated.count.positive? ? updated : "None"}")
+      logger.info(logger_output("Found #{authorizations.count} extended socio demographic authorizations"))
+      logger.info(logger_output("Updated #{updated.count} users : #{updated.count.positive? ? updated : "None"}"))
 
       exit 0
     end
   end
 end
 
-def logger_output(msg ="", task_name = "decidim:duplicates:metadata")
+def logger_output(msg = "", task_name = "decidim:duplicates:metadata")
   "[#{task_name}] :: #{msg}"
 end

--- a/spec/commands/decidim/verifications/authorize_user_spec.rb
+++ b/spec/commands/decidim/verifications/authorize_user_spec.rb
@@ -45,10 +45,22 @@ module Decidim::Verifications
         expect(authorizations.first).to be_granted
       end
 
-      it "duplicates metadata in user extended data" do
+      it "doesn't duplicates metadata in user extended data" do
         subject.call
 
-        expect(user.extended_data).to include("socio_document_number" => document_number)
+        expect(user.extended_data).not_to include("socio_document_number" => document_number)
+      end
+
+      context "when authorization is a ExtendedSocioDemographic" do
+        before do
+          allow(handler).to receive(:is_a?).with(Decidim::ExtendedSocioDemographicAuthorizationHandler).and_return(true)
+        end
+
+        it "duplicates metadata in user extended data" do
+          subject.call
+
+          expect(user.extended_data).to include("socio_document_number" => document_number)
+        end
       end
     end
 

--- a/spec/commands/decidim/verifications/authorize_user_spec.rb
+++ b/spec/commands/decidim/verifications/authorize_user_spec.rb
@@ -1,0 +1,123 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim::Verifications
+  describe AuthorizeUser do
+    subject { described_class.new(handler, organization) }
+
+    let(:organization) { create(:organization) }
+    let(:user) { create(:user, :confirmed) }
+    let(:document_number) { "12345678X" }
+    let(:handler) do
+      DummyAuthorizationHandler.new(
+        document_number: document_number,
+        user: user
+      )
+    end
+
+    let(:authorizations) { Authorizations.new(organization: user.organization, user: user, granted: true) }
+
+    context "when the form is not authorized" do
+      before do
+        expect(handler).to receive(:valid?).and_return(false)
+      end
+
+      it "is not valid" do
+        expect { subject.call }.to broadcast(:invalid)
+      end
+    end
+
+    context "when everything is ok" do
+      it "creates an authorization for the user" do
+        expect { subject.call }.to change(authorizations, :count).by(1)
+      end
+
+      it "stores the metadata" do
+        subject.call
+
+        expect(authorizations.first.metadata["document_number"]).to eq("12345678X")
+      end
+
+      it "sets the authorization as granted" do
+        subject.call
+
+        expect(authorizations.first).to be_granted
+      end
+
+      it "duplicates metadata in user extended data" do
+        subject.call
+
+        expect(user.extended_data).to include("socio_document_number" => document_number)
+      end
+    end
+
+    describe "uniqueness" do
+      let(:unique_id) { "foo" }
+
+      context "when there's no other authorizations" do
+        it "is valid if there's no authorization with the same id" do
+          expect { subject.call }.to change(authorizations, :count).by(1)
+        end
+      end
+
+      context "when there's other authorizations" do
+        let!(:other_user) { create(:user, organization: user.organization) }
+
+        before do
+          create(:authorization,
+                 user: other_user,
+                 unique_id: document_number,
+                 name: handler.handler_name)
+        end
+
+        it "is invalid if there's another authorization with the same id" do
+          expect { subject.call }.to change(authorizations, :count).by(0)
+        end
+      end
+    end
+
+    describe "managed user" do
+      context "when document_id was used by a managed user" do
+        let!(:other_user) { create(:user, managed: true, organization: user.organization) }
+
+        before do
+          create(:authorization,
+                 user: other_user,
+                 unique_id: document_number,
+                 name: handler.handler_name)
+        end
+
+        it "saves conflicts" do
+          expect { subject.call }.to change(Decidim::Verifications::Conflict, :count).by(1)
+        end
+
+        it "increases conflicts times" do
+          subject.call
+
+          conflict = Decidim::Verifications::Conflict.last
+
+          expect(conflict.times).to eq(1)
+
+          subject.call
+
+          expect(conflict.reload.times).to eq(2)
+        end
+
+        it "sends notification to admins" do
+          allow(Decidim::EventsManager).to receive(:publish).and_call_original
+          subject.call
+
+          conflict = Decidim::Verifications::Conflict.last
+
+          expect(Decidim::EventsManager).to have_received(:publish).with(
+            event: "decidim.events.verifications.managed_user_error_event",
+            event_class: Decidim::Verifications::ManagedUserErrorEvent,
+            resource: conflict,
+            affected_users: Decidim::User.where(admin: true, organization: organization)
+          )
+        end
+      end
+    end
+  end
+end

--- a/spec/commands/decidim/verifications/authorize_user_spec.rb
+++ b/spec/commands/decidim/verifications/authorize_user_spec.rb
@@ -53,7 +53,7 @@ module Decidim::Verifications
 
       context "when authorization is a ExtendedSocioDemographic" do
         before do
-          allow(handler).to receive(:is_a?).with(Decidim::ExtendedSocioDemographicAuthorizationHandler).and_return(true)
+          allow(handler.class).to receive(:name).and_return("ExtendedSocioDemographicAuthorizationHandler")
         end
 
         it "duplicates metadata in user extended data" do

--- a/spec/commands/decidim/verifications/destroy_user_authorization_spec.rb
+++ b/spec/commands/decidim/verifications/destroy_user_authorization_spec.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim::Verifications
+  describe DestroyUserAuthorization do
+    subject { described_class.new(authorization) }
+
+    let(:user) { create(:user, :confirmed, extended_data: extended_data) }
+    let(:extended_data) do
+      {
+        "extra_data" => "Extra data",
+        "socio_work_area" => "Work area",
+        "socio_residential_area" => "Residential area",
+      }
+    end
+    let(:metadata) do
+      {
+        "socio_work_area" => "Work area",
+        "socio_residential_area" => "Residential area",
+      }
+    end
+    let(:authorizations) { Authorizations.new(organization: user.organization, user: user, granted: true) }
+
+    context "when no authorization" do
+      let(:authorization) { nil }
+
+      it "is not valid" do
+        expect { subject.call }.to broadcast(:invalid)
+      end
+    end
+
+    context "when everything is ok" do
+      let!(:authorization) { create(:authorization, :granted, name: "extended_socio_demographic_authorization_handler", user: user, metadata: metadata) }
+
+      it "destroys the authorization for the user" do
+        expect { subject.call }.to change(authorizations, :count).by(-1)
+      end
+
+      it "removes metadata in user extended data" do
+        expect(user.extended_data).to eq(extended_data)
+        subject.call
+
+        expect(user.extended_data).to include("extra_data")
+        expect(user.extended_data).not_to include("socio_residential_area")
+        expect(user.extended_data).not_to include("socio_residential_area")
+      end
+
+      context "when authorization is not a ExtendedSocioDemographicAuthorizationHandler" do
+        let!(:authorization) { create(:authorization, :granted, user: user) }
+
+        it "doesn't clear user extended data" do
+          expect { subject.call }.not_to change(user, :extended_data)
+        end
+      end
+    end
+  end
+end

--- a/spec/commands/decidim/verifications/destroy_user_authorization_spec.rb
+++ b/spec/commands/decidim/verifications/destroy_user_authorization_spec.rb
@@ -11,13 +11,13 @@ module Decidim::Verifications
       {
         "extra_data" => "Extra data",
         "socio_work_area" => "Work area",
-        "socio_residential_area" => "Residential area",
+        "socio_residential_area" => "Residential area"
       }
     end
     let(:metadata) do
       {
         "socio_work_area" => "Work area",
-        "socio_residential_area" => "Residential area",
+        "socio_residential_area" => "Residential area"
       }
     end
     let(:authorizations) { Authorizations.new(organization: user.organization, user: user, granted: true) }

--- a/spec/commands/decidim/verifications/revoke_all_authorizations_spec.rb
+++ b/spec/commands/decidim/verifications/revoke_all_authorizations_spec.rb
@@ -1,0 +1,132 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim::Verifications
+  describe RevokeAllAuthorizations do
+    subject { described_class.new(organization, current_user) }
+
+    let(:organization) { create(:organization) }
+    let(:now) { Time.zone.now }
+    let(:prev_week) { Time.zone.today.prev_week }
+    let(:all_authorizations) do
+      Decidim::Verifications::Authorizations.new(
+        organization: organization
+      ).query
+    end
+    let(:granted_authorizations) do
+      Decidim::Verifications::Authorizations.new(
+        organization: organization,
+        granted: true
+      ).query
+    end
+    let(:no_granted_authorizations) do
+      Decidim::Verifications::Authorizations.new(
+        organization: organization,
+        granted: false
+      ).query
+    end
+    let!(:current_user) { create(:user, :admin, :confirmed, organization: organization, extended_data: extended_data) }
+    let!(:user0) { create(:user, :admin, :confirmed, organization: organization, extended_data: extended_data) }
+    let!(:user1) { create(:user, :admin, :confirmed, organization: organization, extended_data: extended_data) }
+    let!(:user2) { create(:user, :admin, :confirmed, organization: organization, extended_data: extended_data) }
+    let!(:user3) { create(:user, :admin, :confirmed, organization: organization, extended_data: extended_data) }
+    let!(:user4) { create(:user, :admin, :confirmed, organization: organization, extended_data: extended_data) }
+    let!(:user5) { create(:user, :admin, :confirmed, organization: organization, extended_data: extended_data, managed: true) }
+
+    let(:extended_data) do
+      {
+        "extra_data" => "Extra data",
+        "socio_work_area" => "Work area",
+        "socio_residential_area" => "Residential area",
+      }
+    end
+    let(:metadata) do
+      {
+        "socio_work_area" => "Work area",
+        "socio_residential_area" => "Residential area",
+      }
+    end
+    # With 6 authorizations, 3 granted, 2 pending, only 1 granted & managed
+    before do
+      create(:authorization, created_at: prev_week, granted_at: prev_week, name: "extended_socio_demographic_authorization_handler", user: user0)
+      create(:authorization, created_at: prev_week, granted_at: prev_week, name: "extended_socio_demographic_authorization_handler", user: user1)
+      create(:authorization, created_at: prev_week, granted_at: prev_week, name: "extended_socio_demographic_authorization_handler", user: user2)
+      create(:authorization, created_at: prev_week, granted_at: nil, name: "extended_socio_demographic_authorization_handler", user: user3)
+      create(:authorization, created_at: prev_week, granted_at: nil, name: "extended_socio_demographic_authorization_handler", user: user4)
+      create(:authorization, created_at: prev_week, granted_at: prev_week, name: "extended_socio_demographic_authorization_handler", user: user5)
+    end
+
+    describe "When creating a revoke all authorizations command" do
+      context "with organization not set" do
+        let(:subject) { described_class.new(nil, current_user) }
+
+        it "is not valid" do
+          expect { subject.call }.to broadcast(:invalid)
+        end
+      end
+    end
+
+    describe "With 4 granted auths and 2 ungranted auths" do
+      context "when destroy all granted auths" do
+        it "doesn't destroy any ungranted auth" do
+          expect do
+            subject.call
+          end.not_to change(no_granted_authorizations, :count)
+        end
+
+        it "destroy all granted auths" do
+          expect do
+            subject.call
+          end.to change(granted_authorizations, :count).from(4).to(0)
+        end
+
+        it "broadcasts ok" do
+          expect { subject.call }.to broadcast(:ok)
+        end
+
+        it "traces the action", versioning: true do
+          granted_authorizations.find_each do |auth|
+            expect(Decidim.traceability)
+              .to receive(:perform_action!)
+              .with(:destroy, auth, current_user)
+              .and_call_original
+          end
+          expect { subject.call }.to change(Decidim::ActionLog, :count)
+          action_log = Decidim::ActionLog.last
+          expect(action_log.version).to be_present
+        end
+
+        it "removes metadata in user extended data" do
+          expect(user0.extended_data).to eq(extended_data)
+          expect(user1.extended_data).to eq(extended_data)
+          subject.call
+
+          user0.reload
+          user1.reload
+          expect(user0.extended_data).to include("extra_data")
+          expect(user0.extended_data).not_to include("socio_residential_area")
+          expect(user0.extended_data).not_to include("socio_residential_area")
+          expect(user1.extended_data).to include("extra_data")
+          expect(user1.extended_data).not_to include("socio_residential_area")
+          expect(user1.extended_data).not_to include("socio_residential_area")
+        end
+
+        context "when authorization is not a ExtendedSocioDemographicAuthorizationHandler" do
+          before do
+            create(:authorization, created_at: prev_week, granted_at: prev_week, user: user0)
+            create(:authorization, created_at: prev_week, granted_at: prev_week, user: user1)
+            create(:authorization, created_at: prev_week, granted_at: prev_week, user: user2)
+            create(:authorization, created_at: prev_week, granted_at: nil, user: user3)
+            create(:authorization, created_at: prev_week, granted_at: nil, user: user4)
+            create(:authorization, created_at: prev_week, granted_at: prev_week, user: user5)
+          end
+
+          it "doesn't clear user extended data" do
+            expect { subject.call }.not_to change(user0, :extended_data)
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/commands/decidim/verifications/revoke_all_authorizations_spec.rb
+++ b/spec/commands/decidim/verifications/revoke_all_authorizations_spec.rb
@@ -38,16 +38,17 @@ module Decidim::Verifications
       {
         "extra_data" => "Extra data",
         "socio_work_area" => "Work area",
-        "socio_residential_area" => "Residential area",
+        "socio_residential_area" => "Residential area"
       }
     end
     let(:metadata) do
       {
         "socio_work_area" => "Work area",
-        "socio_residential_area" => "Residential area",
+        "socio_residential_area" => "Residential area"
       }
     end
     # With 6 authorizations, 3 granted, 2 pending, only 1 granted & managed
+
     before do
       create(:authorization, created_at: prev_week, granted_at: prev_week, name: "extended_socio_demographic_authorization_handler", user: user0)
       create(:authorization, created_at: prev_week, granted_at: prev_week, name: "extended_socio_demographic_authorization_handler", user: user1)

--- a/spec/lib/tasks/duplicates_metadata_spec.rb
+++ b/spec/lib/tasks/duplicates_metadata_spec.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe "rake decidim:repare:nickname", type: :task do
+  let!(:organization) { create(:organization) }
+  let(:task_cmd) { :"decidim:repare:nickname" }
+
+  let!(:user) { create(:user, organization: organization) }
+  let!(:valid_user_2) { create(:user, nickname: "Azerty_Uiop123", organization: organization) }
+  let(:invalid_user_1) { build(:user, nickname: "Foo bar", organization: organization) }
+  let(:invalid_user_2) { build(:user, nickname: "Foo M. bar", organization: organization) }
+  let(:invalid_user_3) { build(:user, nickname: "Foo-Bar_fooo$", organization: organization) }
+  let(:invalid_user_4) { build(:user, nickname: "foo.bar.foo", organization: organization) }
+  let(:invalid_user_5) { build(:user, nickname: ".foobar.foo_bar.", organization: organization) }
+
+  context "when executing task" do
+    before do
+      invalid_user_1.save(validate: false)
+      invalid_user_2.save(validate: false)
+      invalid_user_3.save(validate: false)
+      invalid_user_4.save(validate: false)
+      invalid_user_5.save(validate: false)
+    end
+
+    it "exits with 0 code" do
+      allow($stdin).to receive(:gets).and_return("y")
+
+      expect { Rake::Task[task_cmd].invoke }.to raise_error(SystemExit) do |error|
+        expect(error.status).to eq(0)
+      end
+    end
+
+    context "when user accepts update" do
+      it "updates invalid nicknames" do
+        allow($stdin).to receive(:gets).and_return("y")
+
+        expect { Rake::Task[task_cmd].invoke }.to change(invalid_user_1, :nickname).from("Foo bar").to("foobar")
+
+        invalid_user_1.reload
+        expect(invalid_user_1.nickname).to eq("foobar")
+        invalid_user_2.reload
+        expect(invalid_user_2.nickname).to eq("foombar")
+        invalid_user_3.reload
+        expect(invalid_user_3.nickname).to eq("foobarfooo")
+        invalid_user_4.reload
+        expect(invalid_user_4.nickname).to eq("foobarfoo")
+      end
+    end
+
+    context "when user refuses update" do
+      it "updates invalid nicknames" do
+        allow($stdin).to receive(:gets).and_return("n")
+
+        expect { Rake::Task[task_cmd].invoke }.not_to change(invalid_user_1, :nickname)
+
+        invalid_user_1.reload
+        expect(invalid_user_1.nickname).to eq("Foo bar")
+        invalid_user_2.reload
+        expect(invalid_user_2.nickname).to eq("Foo M. bar")
+        invalid_user_3.reload
+        expect(invalid_user_3.nickname).to eq("Foo-Bar_fooo$")
+        invalid_user_4.reload
+        expect(invalid_user_4.nickname).to eq("foo.bar.foo")
+        invalid_user_5.reload
+        expect(invalid_user_5.nickname).to eq(".foobar.foo_bar.")
+      end
+    end
+  end
+end

--- a/spec/lib/tasks/duplicates_metadata_spec.rb
+++ b/spec/lib/tasks/duplicates_metadata_spec.rb
@@ -2,69 +2,34 @@
 
 require "spec_helper"
 
-describe "rake decidim:repare:nickname", type: :task do
+describe "rake decidim:duplicates:metadata", type: :task do
   let!(:organization) { create(:organization) }
-  let(:task_cmd) { :"decidim:repare:nickname" }
+  let(:task_cmd) { :"decidim:duplicates:metadata" }
 
   let!(:user) { create(:user, organization: organization) }
-  let!(:valid_user_2) { create(:user, nickname: "Azerty_Uiop123", organization: organization) }
-  let(:invalid_user_1) { build(:user, nickname: "Foo bar", organization: organization) }
-  let(:invalid_user_2) { build(:user, nickname: "Foo M. bar", organization: organization) }
-  let(:invalid_user_3) { build(:user, nickname: "Foo-Bar_fooo$", organization: organization) }
-  let(:invalid_user_4) { build(:user, nickname: "foo.bar.foo", organization: organization) }
-  let(:invalid_user_5) { build(:user, nickname: ".foobar.foo_bar.", organization: organization) }
+  let(:authorization) { create(:authorization, user: user, metadata: metadata) }
+  let!(:user2) { create(:user, organization: organization) }
+  let(:authorization_user2) { create(:authorization, user: user2, metadata: metadata_user2) }
+  let(:metadata) { {email: user.email} }
+  let(:metadata_user2) { {email: user2.email} }
 
   context "when executing task" do
-    before do
-      invalid_user_1.save(validate: false)
-      invalid_user_2.save(validate: false)
-      invalid_user_3.save(validate: false)
-      invalid_user_4.save(validate: false)
-      invalid_user_5.save(validate: false)
-    end
-
     it "exits with 0 code" do
-      allow($stdin).to receive(:gets).and_return("y")
-
       expect { Rake::Task[task_cmd].invoke }.to raise_error(SystemExit) do |error|
         expect(error.status).to eq(0)
       end
     end
 
-    context "when user accepts update" do
-      it "updates invalid nicknames" do
-        allow($stdin).to receive(:gets).and_return("y")
+    it "duplicates encrypted metadata to user registration_metadata" do
+      expect(user.extended_data).to eq({})
+      expect(user2.extended_data).to eq({})
+      Rake::Task[task_cmd].invoke
 
-        expect { Rake::Task[task_cmd].invoke }.to change(invalid_user_1, :nickname).from("Foo bar").to("foobar")
-
-        invalid_user_1.reload
-        expect(invalid_user_1.nickname).to eq("foobar")
-        invalid_user_2.reload
-        expect(invalid_user_2.nickname).to eq("foombar")
-        invalid_user_3.reload
-        expect(invalid_user_3.nickname).to eq("foobarfooo")
-        invalid_user_4.reload
-        expect(invalid_user_4.nickname).to eq("foobarfoo")
-      end
+      user.reload!
+      user2.reload!
+      expect(user.extended_data).to eq(metadata)
+      expect(user2.extended_data).to eq(metadata_user2)
     end
 
-    context "when user refuses update" do
-      it "updates invalid nicknames" do
-        allow($stdin).to receive(:gets).and_return("n")
-
-        expect { Rake::Task[task_cmd].invoke }.not_to change(invalid_user_1, :nickname)
-
-        invalid_user_1.reload
-        expect(invalid_user_1.nickname).to eq("Foo bar")
-        invalid_user_2.reload
-        expect(invalid_user_2.nickname).to eq("Foo M. bar")
-        invalid_user_3.reload
-        expect(invalid_user_3.nickname).to eq("Foo-Bar_fooo$")
-        invalid_user_4.reload
-        expect(invalid_user_4.nickname).to eq("foo.bar.foo")
-        invalid_user_5.reload
-        expect(invalid_user_5.nickname).to eq(".foobar.foo_bar.")
-      end
-    end
   end
 end

--- a/spec/lib/tasks/duplicates_metadata_spec.rb
+++ b/spec/lib/tasks/duplicates_metadata_spec.rb
@@ -10,8 +10,8 @@ describe "rake decidim:duplicates:metadata", type: :task do
   let(:authorization) { create(:authorization, user: user, metadata: metadata) }
   let!(:user2) { create(:user, organization: organization) }
   let(:authorization_user2) { create(:authorization, user: user2, metadata: metadata_user2) }
-  let(:metadata) { {email: user.email} }
-  let(:metadata_user2) { {email: user2.email} }
+  let(:metadata) { { email: user.email } }
+  let(:metadata_user2) { { email: user2.email } }
 
   context "when executing task" do
     it "exits with 0 code" do
@@ -30,6 +30,5 @@ describe "rake decidim:duplicates:metadata", type: :task do
       expect(user.extended_data).to eq(metadata)
       expect(user2.extended_data).to eq(metadata_user2)
     end
-
   end
 end


### PR DESCRIPTION
### Description

This new task `bundle exec rake decidim:duplicates:metadata` fetch all socio demographic authorizations and store the metadata in the user's field `extended_data` if not already existing.

Also, when a ExtendedSocioDemographicHandler authorization is created, it duplicates the metadata in the user extended data

Also : 
- [x] Fix maps deprecation
- [x] Duplicates metadata from Extended socio demographic handler directly in user extended data 
