### PR TITLE
Allow to configure session timeout

### DIFF
--- a/.env-example
+++ b/.env-example
@@ -19,4 +19,6 @@ SPAM_DETECTION_EMAIL=
 PERFORM_BLOCK_USER=
 QUESTION_CAPTCHA_HOST=
 # Set Session Timeout (in seconds)
+EXPIRE_SESSION_AFTER=
+# Set Session Timeout check interval (in seconds)
 SESSION_TIMEOUT_INTERVAL=

--- a/config/initializers/decidim.rb
+++ b/config/initializers/decidim.rb
@@ -4,6 +4,10 @@ Decidim.configure do |config|
   config.unconfirmed_access_for = 2.days unless Rails.env.test?
   config.skip_first_login_authorization = ENV["SKIP_FIRST_LOGIN_AUTHORIZATION"] ? ActiveRecord::Type::Boolean.new.cast(ENV["SKIP_FIRST_LOGIN_AUTHORIZATION"]) : true
 
+  if Rails.application.secrets.decidim[:expire_session_after].present?
+    config.expire_session_after = Rails.application.secrets.decidim[:expire_session_after].to_i.seconds
+  end
+
   if Rails.application.secrets.decidim[:session_timeout_interval].present?
     config.session_timeout_interval = Rails.application.secrets.decidim[:session_timeout_interval].to_i.seconds
   end

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -13,6 +13,7 @@
 default: &default
   asset_host: <%= ENV["ASSET_HOST"] %>
   decidim:
+    expire_session_after: <%= ENV["EXPIRE_SESSION_AFTER"] %>
     session_timeout_interval: <%= ENV["SESSION_TIMEOUT_INTERVAL"] %>
   helpscout:
     user:


### PR DESCRIPTION
Redo of PR #56 which mixed up `session_timeout_interval` for `expire_session_after`.

`session_timeout_interval` defines how often session_timeouter.js checks time between current moment and last request.

`expire_session_after` defines how long can a user remained logged in before the session expires **and** also the maximum time that user can be idle before getting automatically signed out. (this is what we wanted in the first place)