### PR TITLE
Feature - Add Data Authorization Handler

### DIFF
--- a/app/services/decidim/data_authorization_handler.rb
+++ b/app/services/decidim/data_authorization_handler.rb
@@ -7,11 +7,9 @@ module Decidim
     attribute :lastname, String
     attribute :phone, String
     attribute :structure, String
-    attribute :gdpr, Boolean
 
-    validates :gdpr, acceptance: true
-    validates :lastname, presence: true
-    validates :firstname, presence: true
+    validates :lastname, presence: true, length: { minimum: 1 }
+    validates :firstname, presence: true, length: { minimum: 1 }
     validates :phone, presence: true,
                       format: { with: /\A(?:(?:\+|00)33[\s.-]{0,3}(?:\(0\)[\s.-]{0,3})?|0)[1-9](?:(?:[\s.-]?\d{2}){4}|\d{2}(?:[\s.-]?\d{3}){2})\z/,
                                 message: I18n.t("decidim.authorization_handlers.data_authorization_handler.errors.phone_invalid") }

--- a/app/services/decidim/data_authorization_handler.rb
+++ b/app/services/decidim/data_authorization_handler.rb
@@ -8,8 +8,8 @@ module Decidim
     attribute :phone, String
     attribute :structure, String
 
-    validates :lastname, presence: true, length: { minimum: 1 }
-    validates :firstname, presence: true, length: { minimum: 1 }
+    validates :lastname, presence: true
+    validates :firstname, presence: true
     validates :phone, presence: true,
                       format: { with: /\A(?:(?:\+|00)33[\s.-]{0,3}(?:\(0\)[\s.-]{0,3})?|0)[1-9](?:(?:[\s.-]?\d{2}){4}|\d{2}(?:[\s.-]?\d{3}){2})\z/,
                                 message: I18n.t("decidim.authorization_handlers.data_authorization_handler.errors.phone_invalid") }

--- a/app/services/decidim/data_authorization_handler.rb
+++ b/app/services/decidim/data_authorization_handler.rb
@@ -12,7 +12,9 @@ module Decidim
     validates :gdpr, acceptance: true
     validates :lastname, presence: true
     validates :firstname, presence: true
-    validates :phone, presence: true, format: { with: /\A(?:(?:\+|00)33[\s.-]{0,3}(?:\(0\)[\s.-]{0,3})?|0)[1-9](?:(?:[\s.-]?\d{2}){4}|\d{2}(?:[\s.-]?\d{3}){2})\z/, message: I18n.t("decidim.authorization_handlers.data_authorization_handler.errors.phone_invalid") }
+    validates :phone, presence: true,
+                      format: { with: /\A(?:(?:\+|00)33[\s.-]{0,3}(?:\(0\)[\s.-]{0,3})?|0)[1-9](?:(?:[\s.-]?\d{2}){4}|\d{2}(?:[\s.-]?\d{3}){2})\z/,
+                                message: I18n.t("decidim.authorization_handlers.data_authorization_handler.errors.phone_invalid") }
     def metadata
       super.merge(firstname: firstname, lastname: lastname, phone: phone, structure: structure)
     end

--- a/app/services/decidim/data_authorization_handler.rb
+++ b/app/services/decidim/data_authorization_handler.rb
@@ -2,6 +2,7 @@
 
 module Decidim
   class DataAuthorizationHandler < Decidim::AuthorizationHandler
+    # Import valid_phone to make it execute
     attribute :firstname, String
     attribute :lastname, String
     attribute :phone, String
@@ -11,8 +12,7 @@ module Decidim
     validates :gdpr, acceptance: true
     validates :lastname, presence: true
     validates :firstname, presence: true
-    validates :phone, presence: true, format: { with: /\A0[1-9]\d{8}\z/, message: I18n.t("decidim.authorization_handlers.data_authorization_handler.errors.phone_invalid") }
-
+    validates :phone, presence: true, format: { with: /\A(?:(?:\+|00)33[\s.-]{0,3}(?:\(0\)[\s.-]{0,3})?|0)[1-9](?:(?:[\s.-]?\d{2}){4}|\d{2}(?:[\s.-]?\d{3}){2})\z/, message: I18n.t("decidim.authorization_handlers.data_authorization_handler.errors.phone_invalid") }
     def metadata
       super.merge(firstname: firstname, lastname: lastname, phone: phone, structure: structure)
     end

--- a/app/services/decidim/data_authorization_handler.rb
+++ b/app/services/decidim/data_authorization_handler.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module Decidim
+  class DataAuthorizationHandler < Decidim::AuthorizationHandler
+    attribute :firstname, String
+    attribute :lastname, String
+    attribute :phone, String
+    attribute :structure, String
+    attribute :gdpr, Boolean
+
+    validates :gdpr, acceptance: true
+    validates :lastname, presence: true
+    validates :firstname, presence: true
+    validates :phone, presence: true, format: { with: /\A0[1-9]\d{8}\z/, message: I18n.t("decidim.authorization_handlers.data_authorization_handler.errors.phone_invalid") }
+
+    def metadata
+      super.merge(firstname: firstname, lastname: lastname, phone: phone, structure: structure)
+    end
+  end
+end

--- a/app/services/decidim/data_authorization_handler.rb
+++ b/app/services/decidim/data_authorization_handler.rb
@@ -8,11 +8,12 @@ module Decidim
     attribute :phone, String
     attribute :structure, String
 
-    validates :lastname, presence: true
-    validates :firstname, presence: true
-    validates :phone, presence: true,
-                      format: { with: /\A(?:(?:\+|00)33[\s.-]{0,3}(?:\(0\)[\s.-]{0,3})?|0)[1-9](?:(?:[\s.-]?\d{2}){4}|\d{2}(?:[\s.-]?\d{3}){2})\z/,
-                                message: I18n.t("decidim.authorization_handlers.data_authorization_handler.errors.phone_invalid") }
+    validates :firstname, presence: true, format: { with: /\A[a-zA-ZÀ-ÿ'\-\s]+\z/,
+                                                    message: I18n.t("decidim.authorization_handlers.data_authorization_handler.errors.error_message") }
+    validates :lastname, presence: true, format: { with: /\A[a-zA-ZÀ-ÿ'\-\s]+\z/,
+                                                   message: I18n.t("decidim.authorization_handlers.data_authorization_handler.errors.error_message") }
+    validates :phone, presence: true
+
     def metadata
       super.merge(firstname: firstname, lastname: lastname, phone: phone, structure: structure)
     end

--- a/app/views/data_authorization/_form.html.erb
+++ b/app/views/data_authorization/_form.html.erb
@@ -1,0 +1,16 @@
+<%= form.hidden_field :handler_name %>
+<div class="field">
+  <%= form.text_field :firstname, label: I18n.t('decidim.authorization_handlers.data_authorization_handler.fields.firstname'), placeholder: I18n.t('decidim.authorization_handlers.data_authorization_handler.placeholder.firstname') %>
+</div>
+<div class="field">
+  <%= form.text_field :lastname, label: I18n.t('decidim.authorization_handlers.data_authorization_handler.fields.lastname'), placeholder: I18n.t('decidim.authorization_handlers.data_authorization_handler.placeholder.lastname')%>
+</div>
+<div class="field">
+  <%= form.text_field :phone, label: I18n.t('decidim.authorization_handlers.data_authorization_handler.fields.phone'), placeholder: I18n.t('decidim.authorization_handlers.data_authorization_handler.placeholder.phone')%>
+</div>
+<div class="field">
+  <%= form.text_field :structure, label: I18n.t('decidim.authorization_handlers.data_authorization_handler.fields.structure'), placeholder: I18n.t('decidim.authorization_handlers.data_authorization_handler.placeholder.structure') %>
+</div>
+<div class="field">
+  <%= form.check_box :gdpr, label: I18n.t('decidim.authorization_handlers.data_authorization_handler.fields.gdpr') %>
+</div>

--- a/app/views/data_authorization/_form.html.erb
+++ b/app/views/data_authorization/_form.html.erb
@@ -2,19 +2,19 @@
 <div class="help-text help-text-form-required-fields">
   * <%= t('decidim.authorization_handlers.data_authorization_handler.help_text.required_fields') %>
 </div>
-<div class="field firstname_field">
-  <%= form.text_field :firstname, label: I18n.t('decidim.authorization_handlers.data_authorization_handler.fields.firstname'), placeholder: I18n.t('decidim.authorization_handlers.data_authorization_handler.placeholder.firstname') %>
-  <p class="help-text"><%= I18n.t('decidim.authorization_handlers.data_authorization_handler.help_text.firstname') %></p>
-</div>
 <div class="field lastname_field">
-  <%= form.text_field :lastname, label: I18n.t('decidim.authorization_handlers.data_authorization_handler.fields.lastname'), placeholder: I18n.t('decidim.authorization_handlers.data_authorization_handler.placeholder.lastname')%>
+  <%= form.text_field :lastname, label: I18n.t('decidim.authorization_handlers.data_authorization_handler.fields.lastname')%>
   <p class="help-text"><%= I18n.t('decidim.authorization_handlers.data_authorization_handler.help_text.lastname') %></p>
 </div>
-<div class="field phone_field">
-  <%= form.text_field :phone, label: I18n.t('decidim.authorization_handlers.data_authorization_handler.fields.phone'), placeholder: I18n.t('decidim.authorization_handlers.data_authorization_handler.placeholder.phone')%>
-  <p class="help-text"><%= I18n.t('decidim.authorization_handlers.data_authorization_handler.help_text.phone') %></p>
+<div class="field firstname_field">
+  <%= form.text_field :firstname, label: I18n.t('decidim.authorization_handlers.data_authorization_handler.fields.firstname')%>
+  <p class="help-text"><%= I18n.t('decidim.authorization_handlers.data_authorization_handler.help_text.firstname') %></p>
 </div>
 <div class="field structure_field">
-  <%= form.text_field :structure, label: I18n.t('decidim.authorization_handlers.data_authorization_handler.fields.structure'), placeholder: I18n.t('decidim.authorization_handlers.data_authorization_handler.placeholder.structure') %>
+  <%= form.text_field :structure, label: I18n.t('decidim.authorization_handlers.data_authorization_handler.fields.structure')%>
   <p class="help-text"><%= I18n.t('decidim.authorization_handlers.data_authorization_handler.help_text.structure') %></p>
+</div>
+<div class="field phone_field">
+  <%= form.text_field :phone, label: I18n.t('decidim.authorization_handlers.data_authorization_handler.fields.phone')%>
+  <p class="help-text"><%= I18n.t('decidim.authorization_handlers.data_authorization_handler.help_text.phone') %></p>
 </div>

--- a/app/views/data_authorization/_form.html.erb
+++ b/app/views/data_authorization/_form.html.erb
@@ -1,16 +1,20 @@
 <%= form.hidden_field :handler_name %>
-<div class="field">
+<div class="help-text help-text-form-required-fields">
+  * <%= t('decidim.authorization_handlers.data_authorization_handler.help_text.required_fields') %>
+</div>
+<div class="field firstname_field">
   <%= form.text_field :firstname, label: I18n.t('decidim.authorization_handlers.data_authorization_handler.fields.firstname'), placeholder: I18n.t('decidim.authorization_handlers.data_authorization_handler.placeholder.firstname') %>
+  <p class="help-text"><%= I18n.t('decidim.authorization_handlers.data_authorization_handler.help_text.firstname') %></p>
 </div>
-<div class="field">
+<div class="field lastname_field">
   <%= form.text_field :lastname, label: I18n.t('decidim.authorization_handlers.data_authorization_handler.fields.lastname'), placeholder: I18n.t('decidim.authorization_handlers.data_authorization_handler.placeholder.lastname')%>
+  <p class="help-text"><%= I18n.t('decidim.authorization_handlers.data_authorization_handler.help_text.lastname') %></p>
 </div>
-<div class="field">
+<div class="field phone_field">
   <%= form.text_field :phone, label: I18n.t('decidim.authorization_handlers.data_authorization_handler.fields.phone'), placeholder: I18n.t('decidim.authorization_handlers.data_authorization_handler.placeholder.phone')%>
+  <p class="help-text"><%= I18n.t('decidim.authorization_handlers.data_authorization_handler.help_text.phone') %></p>
 </div>
-<div class="field">
+<div class="field structure_field">
   <%= form.text_field :structure, label: I18n.t('decidim.authorization_handlers.data_authorization_handler.fields.structure'), placeholder: I18n.t('decidim.authorization_handlers.data_authorization_handler.placeholder.structure') %>
-</div>
-<div class="field">
-  <%= form.check_box :gdpr, label: I18n.t('decidim.authorization_handlers.data_authorization_handler.fields.gdpr') %>
+  <p class="help-text"><%= I18n.t('decidim.authorization_handlers.data_authorization_handler.help_text.structure') %></p>
 </div>

--- a/config/initializers/decidim_verifications.rb
+++ b/config/initializers/decidim_verifications.rb
@@ -22,3 +22,7 @@
 Decidim::Verifications.register_workflow(:osp_authorization_handler) do |auth|
   auth.form = "Decidim::OspAuthorizationHandler"
 end
+
+Decidim::Verifications.register_workflow(:data_authorization_handler) do |auth|
+  auth.form = "Decidim::DataAuthorizationHandler"
+end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -43,7 +43,7 @@ en:
         fields:
           firstname: Firstname
           lastname: Lastname
-          phone: Phone
+          phone: Phone number
           structure: Structure
         help_text:
           firstname: Your firstname must contain at least 1 character and be composed only of letters, spaces and special characters such as - and '.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -48,7 +48,7 @@ en:
         help_text:
           firstname: Your firstname must contain at least 1 character and be composed only of letters, spaces and special characters such as - and '.
           lastname: Your lastname must contain at least 1 character and be composed only of letters, spaces and special characters such as - and '.
-          phone: Your phone number must contain at least 1 character
+          phone: Enter your phone number
           required_fields: Required fields are marked with an asterisk
           structure: Your structure must contain at least 1 character
         name: Data Sharing Process

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -42,10 +42,15 @@ en:
           phone_invalid: Your phone must contain 10 digits.
         fields:
           firstname: Firstname
-          gdpr: I accept that my data be used for the creation of a proposal
           lastname: Lastname
           phone: Phone
           structure: Structure
+        help_text:
+          firstname: at least 1 character.
+          lastname: at least 1 character.
+          phone: 10 digits and match a correct format.
+          required_fields: Required fields are marked with an asterisk
+          structure: at least 1 character.
         name: Data Sharing Process
         placeholder:
           firstname: Insert your firstname..

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -39,24 +39,19 @@ en:
     authorization_handlers:
       data_authorization_handler:
         errors:
-          phone_invalid: Your phone must contain 10 digits.
+          error_message: This field contains an error
         fields:
           firstname: Firstname
           lastname: Lastname
           phone: Phone
           structure: Structure
         help_text:
-          firstname: at least 1 character.
-          lastname: at least 1 character.
-          phone: 10 digits and match a correct format.
+          firstname: Your firstname must contain at least 1 character and be composed only of letters, spaces and special characters such as - and '.
+          lastname: Your lastname must contain at least 1 character and be composed only of letters, spaces and special characters such as - and '.
+          phone: Your phone number must contain at least 1 character
           required_fields: Required fields are marked with an asterisk
-          structure: at least 1 character.
+          structure: Your structure must contain at least 1 character
         name: Data Sharing Process
-        placeholder:
-          firstname: Insert your firstname..
-          lastname: Insert your lastname..
-          phone: 0601010101..
-          structure: Insert your structure..
       osp_authorization_handler:
         explanation: Vérifier votre identité en saisissant un numéro unique
         fields:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -37,6 +37,21 @@ en:
             Cet amendement pour le %{amendable_type} %{proposal_link}
             est en cours d’évaluation.
     authorization_handlers:
+      data_authorization_handler:
+        errors:
+          phone_invalid: Your phone must contain 10 digits and match 0601010101.
+        fields:
+          firstname: Firstname
+          gdpr: I accept that my data be used for the creation of a proposal
+          lastname: Lastname
+          phone: Phone
+          structure: Structure
+        name: Data Sharing Process
+        placeholder:
+          firstname: Insert your firstname..
+          lastname: Insert your lastname..
+          phone: 0601010101..
+          structure: Insert your structure..
       osp_authorization_handler:
         explanation: Vérifier votre identité en saisissant un numéro unique
         fields:
@@ -59,8 +74,7 @@ en:
         too_fast_modal:
           buttons:
             close_modal: Close modal
-          notice: |-
-            You have completed the sign up form too fast. Please try again.
+          notice: You have completed the sign up form too fast. Please try again.
           title: Registration error
     events:
       budgets:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -39,7 +39,7 @@ en:
     authorization_handlers:
       data_authorization_handler:
         errors:
-          phone_invalid: Your phone must contain 10 digits and match 0601010101.
+          phone_invalid: Your phone must contain 10 digits.
         fields:
           firstname: Firstname
           gdpr: I accept that my data be used for the creation of a proposal

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -35,18 +35,17 @@ fr:
     authorization_handlers:
       data_authorization_handler:
         errors:
-          duplicated_number: Ce numéro de téléphone a déjà été utilisé
           error_message: Ce champ contient une erreur
         explanation: Vérifier votre identité
         fields:
           firstname: Prénom
           lastname: Nom
-          phone: Téléphone
+          phone: Numéro de téléphone
           structure: Structure
         help_text:
           firstname: Votre prénom doit comporter au moins 1 caractère et n'être composé que de lettres, d'espaces et de caractères spéciaux tels que - et '.
           lastname: Votre nom doit comporter au moins 1 caractère et n'être composé que de lettres, d'espaces et de caractères spéciaux tels que - et '.
-          phone: Insérez votre numéro de téléphone
+          phone: Entrez votre numéro de téléphone
           required_fields: Les champs obligatoires sont marqués d'un astérisque
           structure: Votre structure doit comporter au moins 1 caractère
         name: Procédure de partage de données

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -39,10 +39,15 @@ fr:
         explanation: Vérifier votre identité
         fields:
           firstname: Prénom
-          gdpr: J'accepte que mes données soient utilisées pour la création d'une proposition
           lastname: Nom
           phone: Téléphone
           structure: Structure
+        help_text:
+          firstname: au moins 1 caractère.
+          lastname: au moins 1 caractère.
+          phone: 10 chiffres et correspondre à un format correct.
+          required_fields: Les champs obligatoires sont marqués d'un astérisque
+          structure: au moins 1 caractère.
         name: Procédure de partage de données
         placeholder:
           firstname: Insérez votre prénom..

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -35,7 +35,8 @@ fr:
     authorization_handlers:
       data_authorization_handler:
         errors:
-          phone_invalid: Votre téléphone doit contenir 10 chiffres.
+          duplicated_number: Ce numéro de téléphone a déjà été utilisé
+          error_message: Ce champ contient une erreur
         explanation: Vérifier votre identité
         fields:
           firstname: Prénom
@@ -43,17 +44,12 @@ fr:
           phone: Téléphone
           structure: Structure
         help_text:
-          firstname: au moins 1 caractère.
-          lastname: au moins 1 caractère.
-          phone: 10 chiffres et correspondre à un format correct.
+          firstname: Votre prénom doit comporter au moins 1 caractère et n'être composé que de lettres, d'espaces et de caractères spéciaux tels que - et '.
+          lastname: Votre nom doit comporter au moins 1 caractère et n'être composé que de lettres, d'espaces et de caractères spéciaux tels que - et '.
+          phone: Insérez votre numéro de téléphone
           required_fields: Les champs obligatoires sont marqués d'un astérisque
-          structure: au moins 1 caractère.
+          structure: Votre structure doit comporter au moins 1 caractère
         name: Procédure de partage de données
-        placeholder:
-          firstname: Insérez votre prénom..
-          lastname: Insérez votre nom..
-          phone: 0601010101..
-          structure: Insérez votre structure..
       osp_authorization_handler:
         explanation: Vérifier votre identité en saisissant un numéro unique
         fields:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -35,7 +35,7 @@ fr:
     authorization_handlers:
       data_authorization_handler:
         errors:
-          phone_invalid: Votre téléphone doit contenir 10 chiffres et ressembler à 0601010101.
+          phone_invalid: Votre téléphone doit contenir 10 chiffres.
         explanation: Vérifier votre identité
         fields:
           firstname: Prénom

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -33,6 +33,22 @@ fr:
             Cet amendement pour le %{amendable_type} %{proposal_link}
             est en cours d’évaluation.
     authorization_handlers:
+      data_authorization_handler:
+        errors:
+          phone_invalid: Votre téléphone doit contenir 10 chiffres et ressembler à 0601010101.
+        explanation: Vérifier votre identité
+        fields:
+          firstname: Prénom
+          gdpr: J'accepte que mes données soient utilisées pour la création d'une proposition
+          lastname: Nom
+          phone: Téléphone
+          structure: Structure
+        name: Procédure de partage de données
+        placeholder:
+          firstname: Insérez votre prénom..
+          lastname: Insérez votre nom..
+          phone: 0601010101..
+          structure: Insérez votre structure..
       osp_authorization_handler:
         explanation: Vérifier votre identité en saisissant un numéro unique
         fields:
@@ -55,8 +71,7 @@ fr:
         too_fast_modal:
           buttons:
             close_modal: Fermer
-          notice: |-
-            Vous avez complété le formulaire d'inscription trop vite. Vous devez rééssayer.
+          notice: Vous avez complété le formulaire d'inscription trop vite. Vous devez rééssayer.
           title: Erreur d'inscription
     events:
       budgets:

--- a/spec/commands/decidim/verifications/authorize_user_spec.rb
+++ b/spec/commands/decidim/verifications/authorize_user_spec.rb
@@ -20,7 +20,7 @@ module Decidim::Verifications
 
     context "when the form is not authorized" do
       before do
-        expect(handler).to receive(:valid?).and_return(false)
+        allow(handler).to receive(:valid?).and_return(false)
       end
 
       it "is not valid" do

--- a/spec/shared/create_initiative_type_example.rb
+++ b/spec/shared/create_initiative_type_example.rb
@@ -37,7 +37,7 @@ shared_examples "create an initiative type" do
 
     describe "when the form is not valid" do
       before do
-        expect(form).to receive(:invalid?).and_return(true)
+        allow(form).to receive(:invalid?).and_return(true)
       end
 
       it "broadcasts invalid" do

--- a/spec/system/data_authorization_spec.rb
+++ b/spec/system/data_authorization_spec.rb
@@ -31,7 +31,6 @@ describe "Data authorization", type: :system do
       fill_in :authorization_handler_lastname, with: lastname
       fill_in :authorization_handler_phone, with: phone
       fill_in :authorization_handler_structure, with: structure
-      check :authorization_handler_gdpr
       click_button "Send"
     end
 
@@ -76,23 +75,11 @@ describe "Data authorization", type: :system do
       fill_in :authorization_handler_lastname, with: lastname
       fill_in :authorization_handler_phone, with: phone
       fill_in :authorization_handler_structure, with: structure
-      check :authorization_handler_gdpr
     end
 
     shared_examples_for "is not a valid phone number" do |phone|
       it "is a valid phone number: #{phone}" do
         expect(page).to have_content("Your phone must contain 10 digits.")
-      end
-    end
-
-    describe "when the gdpr checkbox is not checked" do
-      before do
-        uncheck :authorization_handler_gdpr
-        click_button "Send"
-      end
-
-      it "does not authorize the user" do
-        expect(page).to have_content("must be accepted")
       end
     end
 

--- a/spec/system/data_authorization_spec.rb
+++ b/spec/system/data_authorization_spec.rb
@@ -80,8 +80,44 @@ describe "Data authorization", type: :system do
         click_button "Send"
       end
 
-      it "does not authorize the user" do
+      it "authorizes the user" do
         expect(page).to have_content("Your phone must contain 10 digits and match 0601010101.")
+      end
+    end
+
+    describe "when the phone number contains spaces" do
+      before do
+        fill_in :authorization_handler_phone, with: "06 12 34 56 78"
+        check :authorization_handler_gdpr
+        click_button "Send"
+      end
+
+      it "authorizes the user" do
+        expect(page).to have_content("successfully")
+      end
+    end
+
+    describe "when the phone numbers starts with 0033" do
+      before do
+        fill_in :authorization_handler_phone, with: "0033650065422"
+        check :authorization_handler_gdpr
+        click_button "Send"
+      end
+
+      it "does not authorize the user" do
+        expect(page).to have_content("successfully")
+      end
+    end
+
+    describe "when the phone numbers starts with +33" do
+      before do
+        fill_in :authorization_handler_phone, with: "+33650065422"
+        check :authorization_handler_gdpr
+        click_button "Send"
+      end
+
+      it "authorizes the user" do
+        expect(page).to have_content("successfully")
       end
     end
 
@@ -99,7 +135,7 @@ describe "Data authorization", type: :system do
 
     describe "when the name is empty" do
       before do
-        fill_in :authorization_handler_firstname, with: ""
+        fill_in :authorization_handler_lastname, with: ""
         check :authorization_handler_gdpr
         click_button "Send"
       end

--- a/spec/system/data_authorization_spec.rb
+++ b/spec/system/data_authorization_spec.rb
@@ -34,34 +34,64 @@ describe "Data authorization", type: :system do
       click_button "Send"
     end
 
-    shared_examples_for "is a valid phone number" do |phone|
-      it "is a valid phone number: #{phone}" do
+    shared_examples_for "is a valid firstname" do
+      it "is valid" do
         expect(page).to have_content("successfully")
       end
     end
 
-    context "when the phone number is equal to 0601010101" do
-      let(:phone) { "0601010101" }
+    context "when the firstname is valid" do
+      let(:firstname) { "John" }
 
-      it_behaves_like "is a valid phone number", "0601010101"
+      it_behaves_like "is a valid firstname"
     end
 
-    context "when the phone number is equal to 06 12 34 56 78" do
-      let(:phone) { "06 12 34 56 78" }
+    context "when the firstname contains ' or -" do
+      let(:firstname) { "Jo-hn's" }
 
-      it_behaves_like "is a valid phone number", "06 12 34 56 78"
+      it_behaves_like "is a valid firstname"
     end
 
-    context "when the phone number is equal to 0033650065422" do
-      let(:phone) { "0033650065422" }
+    context "when the firstname contains a space" do
+      let(:firstname) { "John Doe" }
 
-      it_behaves_like "is a valid phone number", "0033650065422"
+      it_behaves_like "is a valid firstname"
     end
 
-    context "when the phone number is equal to +33650065422" do
-      let(:phone) { "+33650065422" }
+    context "when the firstname contains an accent" do
+      let(:firstname) { "Jöhn Tâylot" }
 
-      it_behaves_like "is a valid phone number", "+33650065422"
+      it_behaves_like "is a valid firstname"
+    end
+
+    shared_examples_for "is a valid lastname" do
+      it "is valid" do
+        expect(page).to have_content("successfully")
+      end
+    end
+
+    context "when the lastname is valid" do
+      let(:lastname) { "Doe" }
+
+      it_behaves_like "is a valid lastname"
+    end
+
+    context "when the lastname contains ' or -" do
+      let(:lastname) { "Do-e's" }
+
+      it_behaves_like "is a valid lastname"
+    end
+
+    context "when the lastname contains a space" do
+      let(:lastname) { "Doe John" }
+
+      it_behaves_like "is a valid lastname"
+    end
+
+    context "when the lastname contains accents" do
+      let(:lastname) { "Maël-Taylôr" }
+
+      it_behaves_like "is a valid lastname"
     end
 
     it "authorizes the user" do
@@ -77,30 +107,56 @@ describe "Data authorization", type: :system do
       fill_in :authorization_handler_structure, with: structure
     end
 
-    shared_examples_for "is not a valid phone number" do |phone|
-      it "is a valid phone number: #{phone}" do
-        expect(page).to have_content("Your phone must contain 10 digits.")
+    shared_examples_for "is an invalid firstname" do
+      it "is invalid" do
+        expect(page).to have_content("contains an error")
       end
     end
 
-    context "when the phone number is equal to 0012345678" do
-      let(:phone) { "0012345678" }
+    context "when the firstname contains number" do
+      let(:firstname) { "John1" }
 
       before do
         click_button "Send"
       end
 
-      it_behaves_like "is not a valid phone number", "0012345678"
+      it_behaves_like "is an invalid firstname"
     end
 
-    context "when the phone number is equal to 123456789a" do
-      let(:phone) { "123456789a" }
+    context "when the firstname contains special characters" do
+      let(:firstname) { "John@" }
 
       before do
         click_button "Send"
       end
 
-      it_behaves_like "is not a valid phone number", "123456789a"
+      it_behaves_like "is an invalid firstname"
+    end
+
+    shared_examples_for "is an invalid lastname" do
+      it "is invalid" do
+        expect(page).to have_content("contains an error")
+      end
+    end
+
+    context "when the lastname contains number" do
+      let(:lastname) { "Doe1" }
+
+      before do
+        click_button "Send"
+      end
+
+      it_behaves_like "is an invalid lastname"
+    end
+
+    context "when the lastname contains special characters" do
+      let(:lastname) { "Doe@" }
+
+      before do
+        click_button "Send"
+      end
+
+      it_behaves_like "is an invalid lastname"
     end
 
     describe "when the name is empty" do

--- a/spec/system/data_authorization_spec.rb
+++ b/spec/system/data_authorization_spec.rb
@@ -35,10 +35,37 @@ describe "Data authorization", type: :system do
       click_button "Send"
     end
 
+    shared_examples_for "is a valid phone number" do |phone|
+      it "is a valid phone number: #{phone}" do
+        expect(page).to have_content("successfully")
+      end
+    end
+
+    context "when the phone number is equal to 0601010101" do
+      let(:phone) { "0601010101" }
+
+      it_behaves_like "is a valid phone number", "0601010101"
+    end
+
+    context "when the phone number is equal to 06 12 34 56 78" do
+      let(:phone) { "06 12 34 56 78" }
+
+      it_behaves_like "is a valid phone number", "06 12 34 56 78"
+    end
+
+    context "when the phone number is equal to 0033650065422" do
+      let(:phone) { "0033650065422" }
+
+      it_behaves_like "is a valid phone number", "0033650065422"
+    end
+
+    context "when the phone number is equal to +33650065422" do
+      let(:phone) { "+33650065422" }
+
+      it_behaves_like "is a valid phone number", "+33650065422"
+    end
+
     it "authorizes the user" do
-      # Check if 0605040302 match /\A0[1-9]\d{8}\z/
-      puts "AAAAAA"
-      puts phone.match(/\A0[1-9]\d{8}\z/)
       expect(page).to have_content("successfully")
     end
   end
@@ -49,10 +76,18 @@ describe "Data authorization", type: :system do
       fill_in :authorization_handler_lastname, with: lastname
       fill_in :authorization_handler_phone, with: phone
       fill_in :authorization_handler_structure, with: structure
+      check :authorization_handler_gdpr
+    end
+
+    shared_examples_for "is not a valid phone number" do |phone|
+      it "is a valid phone number: #{phone}" do
+        expect(page).to have_content("Your phone must contain 10 digits.")
+      end
     end
 
     describe "when the gdpr checkbox is not checked" do
       before do
+        uncheck :authorization_handler_gdpr
         click_button "Send"
       end
 
@@ -61,82 +96,30 @@ describe "Data authorization", type: :system do
       end
     end
 
-    describe "when the phone number is not valid" do
+    context "when the phone number is equal to 0012345678" do
+      let(:phone) { "0012345678" }
+
       before do
-        fill_in :authorization_handler_phone, with: "123"
-        check :authorization_handler_gdpr
         click_button "Send"
       end
 
-      it "does not authorize the user" do
-        expect(page).to have_content("Your phone must contain 10 digits and match 0601010101.")
-      end
+      it_behaves_like "is not a valid phone number", "0012345678"
     end
 
-    describe "when the phone number starts with 00" do
+    context "when the phone number is equal to 123456789a" do
+      let(:phone) { "123456789a" }
+
       before do
-        fill_in :authorization_handler_phone, with: "0012345678"
-        check :authorization_handler_gdpr
         click_button "Send"
       end
 
-      it "authorizes the user" do
-        expect(page).to have_content("Your phone must contain 10 digits and match 0601010101.")
-      end
-    end
-
-    describe "when the phone number contains spaces" do
-      before do
-        fill_in :authorization_handler_phone, with: "06 12 34 56 78"
-        check :authorization_handler_gdpr
-        click_button "Send"
-      end
-
-      it "authorizes the user" do
-        expect(page).to have_content("successfully")
-      end
-    end
-
-    describe "when the phone numbers starts with 0033" do
-      before do
-        fill_in :authorization_handler_phone, with: "0033650065422"
-        check :authorization_handler_gdpr
-        click_button "Send"
-      end
-
-      it "does not authorize the user" do
-        expect(page).to have_content("successfully")
-      end
-    end
-
-    describe "when the phone numbers starts with +33" do
-      before do
-        fill_in :authorization_handler_phone, with: "+33650065422"
-        check :authorization_handler_gdpr
-        click_button "Send"
-      end
-
-      it "authorizes the user" do
-        expect(page).to have_content("successfully")
-      end
-    end
-
-    describe "when the phone number contains letters" do
-      before do
-        fill_in :authorization_handler_phone, with: "123456789a"
-        check :authorization_handler_gdpr
-        click_button "Send"
-      end
-
-      it "does not authorize the user" do
-        expect(page).to have_content("Your phone must contain 10 digits and match 0601010101.")
-      end
+      it_behaves_like "is not a valid phone number", "123456789a"
     end
 
     describe "when the name is empty" do
+      let(:lastname) { "" }
+
       before do
-        fill_in :authorization_handler_lastname, with: ""
-        check :authorization_handler_gdpr
         click_button "Send"
       end
 
@@ -146,9 +129,9 @@ describe "Data authorization", type: :system do
     end
 
     describe "when the firstname is empty" do
+      let(:firstname) { "" }
+
       before do
-        fill_in :authorization_handler_firstname, with: ""
-        check :authorization_handler_gdpr
         click_button "Send"
       end
 

--- a/spec/system/data_authorization_spec.rb
+++ b/spec/system/data_authorization_spec.rb
@@ -1,0 +1,124 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe "Data authorization", type: :system do
+  let(:organization) { create(:organization, available_authorizations: ["data_authorization_handler"]) }
+  let(:user) { create(:user, :confirmed, organization: organization) }
+  let(:firstname) { "John" }
+  let(:lastname) { "Doe" }
+  let(:phone) { "0605040302" }
+  let(:structure) { "My company" }
+
+  before do
+    switch_to_host(organization.host)
+    login_as user, scope: :user
+    visit decidim_verifications.authorizations_path
+    click_link("Data Sharing Process")
+  end
+
+  it "can be authorized" do
+    expect(page).to have_content("Data Sharing Process")
+  end
+
+  context "when the form is filled in correctly" do
+    before do
+      switch_to_host(organization.host)
+      login_as user, scope: :user
+      visit decidim_verifications.authorizations_path
+      click_link("Data Sharing Process")
+      fill_in :authorization_handler_firstname, with: firstname
+      fill_in :authorization_handler_lastname, with: lastname
+      fill_in :authorization_handler_phone, with: phone
+      fill_in :authorization_handler_structure, with: structure
+      check :authorization_handler_gdpr
+      click_button "Send"
+    end
+
+    it "authorizes the user" do
+      # Check if 0605040302 match /\A0[1-9]\d{8}\z/
+      puts "AAAAAA"
+      puts phone.match(/\A0[1-9]\d{8}\z/)
+      expect(page).to have_content("successfully")
+    end
+  end
+
+  context "when the form is filled in incorrectly" do
+    before do
+      fill_in :authorization_handler_firstname, with: firstname
+      fill_in :authorization_handler_lastname, with: lastname
+      fill_in :authorization_handler_phone, with: phone
+      fill_in :authorization_handler_structure, with: structure
+    end
+
+    describe "when the gdpr checkbox is not checked" do
+      before do
+        click_button "Send"
+      end
+
+      it "does not authorize the user" do
+        expect(page).to have_content("must be accepted")
+      end
+    end
+
+    describe "when the phone number is not valid" do
+      before do
+        fill_in :authorization_handler_phone, with: "123"
+        check :authorization_handler_gdpr
+        click_button "Send"
+      end
+
+      it "does not authorize the user" do
+        expect(page).to have_content("Your phone must contain 10 digits and match 0601010101.")
+      end
+    end
+
+    describe "when the phone number starts with 00" do
+      before do
+        fill_in :authorization_handler_phone, with: "0012345678"
+        check :authorization_handler_gdpr
+        click_button "Send"
+      end
+
+      it "does not authorize the user" do
+        expect(page).to have_content("Your phone must contain 10 digits and match 0601010101.")
+      end
+    end
+
+    describe "when the phone number contains letters" do
+      before do
+        fill_in :authorization_handler_phone, with: "123456789a"
+        check :authorization_handler_gdpr
+        click_button "Send"
+      end
+
+      it "does not authorize the user" do
+        expect(page).to have_content("Your phone must contain 10 digits and match 0601010101.")
+      end
+    end
+
+    describe "when the name is empty" do
+      before do
+        fill_in :authorization_handler_firstname, with: ""
+        check :authorization_handler_gdpr
+        click_button "Send"
+      end
+
+      it "does not authorize the user" do
+        expect(page).to have_content("error")
+      end
+    end
+
+    describe "when the firstname is empty" do
+      before do
+        fill_in :authorization_handler_firstname, with: ""
+        check :authorization_handler_gdpr
+        click_button "Send"
+      end
+
+      it "does not authorize the user" do
+        expect(page).to have_content("error")
+      end
+    end
+  end
+end


### PR DESCRIPTION
Hello ! I'm doing this pull request to suggest you the addition of a Data Authorization Handler when the user wants to create a new proposal.

This authorization handler will ask you to fill in your name, your firstname, your phone with a mandatory aspect, and a structure if the users has one to fill in.

To activate it you should go into the participatory processes and add this authorization handler to your Proposals settings.

If you have some requests to me or if some things bother you don't mind asking me !

(n.b. There are two files that are changed that replace "expect" to "allow" but actually it was some easy changes to make the linter not break but that are not actually linked to the feature.)