### PR TITLE
Switch JQuery selector between AH and impersonate view

### DIFF
--- a/app/packs/src/decidim/address.js
+++ b/app/packs/src/decidim/address.js
@@ -112,8 +112,17 @@ class AhFormHTML {
 
 // On page loading, set the cities list in select field if it is already set in session storage
 $(document).ready(() => {
-    const $citiesElement = $("#authorization_handler_city");
-    const $postalCode = $("#authorization_handler_zipcode");
+    if ($("[id*='new_impersonate_user']").length > 0) {
+        var citiesElementIdentifier = "[id*='authorization_city']"
+        var postalCodeIdentifier = "[id*='authorization_postal_code']"
+    } else {
+        var citiesElementIdentifier = "#authorization_handler_city"
+        var postalCodeIdentifier = "#authorization_handler_zipcode"
+    }
+
+    const $citiesElement = $(citiesElementIdentifier);
+    const $postalCode = $(postalCodeIdentifier);
+
     const sessionStorageManager = new SessionStorageManager();
     const ahApi = new AhApi(sessionStorageManager);
     const ahFormHTML = new AhFormHTML($citiesElement);


### PR DESCRIPTION
#### Description

On ne peut pas représenter un utilisateur car le champ Ville  ne se complète pas automatiquement à partir du Code postal 

View impersonate user render Extended socio demographic AH form but changes element identifier and can't be reach in JS

#### Related card

* Notion : https://www.notion.so/opensourcepolitics/CD44-Probl-me-repr-sentation-d-utilisateurs-14136e7de3a246e4bce6e533ca015db3
