### PR TITLE
Fix images in newsletters

### DIFF
--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -140,6 +140,8 @@ ignore_missing:
  - decidim.budgets.admin.imports.help.paper_ballot_results
  - decidim.budgets.admin.imports.label.paper_ballot_results
  - decidim.budgets.admin.imports.title.paper_ballot_results
+ - decidim.editor_images.create.error
+ - decidim.editor_images.create.success
 
 
 

--- a/config/initializers/extends.rb
+++ b/config/initializers/extends.rb
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+require "extends/controllers/decidim/editor_images_controller_extends"

--- a/lib/extends/controllers/decidim/editor_images_controller_extends.rb
+++ b/lib/extends/controllers/decidim/editor_images_controller_extends.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module EditorImagesExtends
+  def create
+    enforce_permission_to :create, :editor_image
+
+    @form = form(Decidim::EditorImageForm).from_params(form_values)
+
+    Decidim::CreateEditorImage.call(@form) do
+      on(:ok) do |image|
+        render json: { url: image.attached_uploader(:file).url(host: current_organization.host), message: I18n.t("success", scope: "decidim.editor_images.create") }
+      end
+
+      on(:invalid) do |_message|
+        render json: { message: I18n.t("error", scope: "decidim.editor_images.create") }, status: :unprocessable_entity
+      end
+    end
+  end
+end
+
+Decidim::EditorImagesController.class_eval do
+  prepend(EditorImagesExtends)
+end

--- a/spec/controllers/editor_images_controller_spec.rb
+++ b/spec/controllers/editor_images_controller_spec.rb
@@ -1,0 +1,92 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim
+  describe EditorImagesController, type: :controller do
+    routes { Decidim::Core::Engine.routes }
+
+    let(:organization) { create(:organization) }
+    let(:editor_images_path) { Rails.application.routes.url_helpers.editor_images_url(organization.open_data_file.blob, only_path: true) }
+    let(:user) { create(:user, :confirmed, organization: organization) }
+    let(:admin) { create(:user, :confirmed, :admin, organization: organization) }
+    let(:image) do
+      Rack::Test::UploadedFile.new(
+        Decidim::Dev.test_file("city.jpeg", "image/jpeg"),
+        "image/jpeg"
+      )
+    end
+    let(:invalid_image) do
+      Rack::Test::UploadedFile.new(
+        Decidim::Dev.test_file("invalid.jpeg", "image/jpeg"),
+        "image/jpeg"
+      )
+    end
+    let(:valid_params) { { image: image } }
+    let(:invalid_params) { { image: invalid_image } }
+
+    before do
+      request.env["decidim.current_organization"] = organization
+    end
+
+    describe "POST create" do
+      context "when no user is signed in" do
+        it "doesn't create an editor image" do
+          expect do
+            post :create, params: valid_params
+          end.not_to(change { Decidim::EditorImage.count })
+
+          expect(response).to have_http_status(:redirect)
+        end
+      end
+
+      context "when user has no admin permissions" do
+        before do
+          sign_in user
+        end
+
+        it "doesn't create an editor image" do
+          expect do
+            post :create, params: valid_params
+          end.not_to(change { Decidim::EditorImage.count })
+
+          expect(response).to have_http_status(:redirect)
+        end
+      end
+
+      context "when admin is signed in" do
+        before do
+          sign_in admin
+        end
+
+        it "creates an editor image" do
+          expect do
+            post :create, params: valid_params
+          end.to change { Decidim::EditorImage.count }.by(1)
+
+          expect(response).to have_http_status(:ok)
+        end
+
+        it "returns full image url" do
+          expect do
+            post :create, params: valid_params
+          end.to change { Decidim::EditorImage.count }.by(1)
+
+          active_storage_path = Decidim::EditorImage.first.attached_uploader(:file).path
+          expect(response.body).to eq({ url: "http://#{organization.host}#{active_storage_path}", message: "Image uploaded successfully" }.to_json)
+        end
+
+        context "when file is not valid" do
+          it "doesn't create an editor image and returns an error message" do
+            expect do
+              post :create, params: invalid_params
+            end.not_to(change { Decidim::EditorImage.count })
+
+            expect(response).to have_http_status(:unprocessable_entity)
+            expect(response.body).to include("Error uploading image")
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
🎩 Description

Please describe your pull request.

When admin uploads an image in newsletter body using Quill Editor JS, AJAX response only contains relative path of URL. When user opens the newsletter in a mailer, image is missing.

Testing

Describe the best way to test or validate your PR.

    Create newsletter
    Import image using editor
    Send newsletter
    In letter_opener, you should see the image, AND url must include current host ex: http://localhost:3000/rails/....

NOTE: In local image can be missing since the added host isn't localhost:3000 but localhost
Tasks

    Add specs