### PR TITLE
fix:Initiative create and edit form

### DIFF
--- a/app/views/decidim/initiatives/create_initiative/fill_data.html.erb
+++ b/app/views/decidim/initiatives/create_initiative/fill_data.html.erb
@@ -1,0 +1,112 @@
+<% content_for :back_link do %>
+  <%= link_to :back do %>
+    <%= icon "chevron-left", class: "icon--small", role: "img", "aria-hidden": true %>
+    <%= t(".back") %>
+  <% end %>
+<% end %>
+
+<div class="row column">
+  <div class="medium-centered">
+    <div class="callout secondary">
+      <%== t ".fill_data_help" %>
+      <%= link_to t(".more_information"), decidim.page_path("initiatives"), target: "_blank" %>.
+    </div>
+  </div>
+</div>
+<br>
+<div class="row">
+  <div class="medium-centered">
+    <div class="card">
+      <div class="card__content">
+        <%= decidim_form_for(@form, url: next_wizard_path, method: :put, html: { class: "form new_initiative_form" }) do |f| %>
+          <%= form_required_explanation %>
+          <div class=section>
+            <% if single_initiative_type? %>
+              <%= f.hidden_field :type_id %>
+            <% else %>
+              <div class="field">
+                <%= f.select :type_id,
+                             initiative_type_options,
+                             {},
+                             {
+                               disabled: !@form.signature_type_updatable?,
+                               "data-scope-selector": "initiative_decidim_scope_id",
+                               "data-scope-id": f.object.scope_id.to_s,
+                               "data-scope-search-url": decidim_initiatives.initiative_type_scopes_search_url,
+                               "data-signature-types-selector": "initiative_signature_type",
+                               "data-signature-type": current_initiative&.signature_type,
+                               "data-signature-types-search-url": decidim_initiatives.initiative_type_signature_types_search_url
+                             } %>
+              </div>
+            <% end %>
+
+            <div class="field">
+              <%= f.text_field :title, autofocus: true %>
+            </div>
+
+            <div class="field">
+              <%= text_editor_for(f, :description, lines: 8, toolbar: :content) %>
+            </div>
+
+            <div class="field">
+              <%= f.text_field :hashtag %>
+            </div>
+
+              <% signature_type_options = signature_type_options(f.object) %>
+              <% if signature_type_options.length == 1 %>
+                <%= f.hidden_field :signature_type, value: signature_type_options.first.last %>
+              <% else %>
+                <%= f.hidden_field :signature_type, value: signature_type_options.last.last %>
+              <% end %>
+
+            <% if initiative_type.custom_signature_end_date_enabled? %>
+              <div class="field">
+                <%= f.date_field :signature_end_date %>
+              </div>
+            <% end %>
+
+            <% if scopes.length == 1 %>
+              <%= f.hidden_field :scope_id, value: scopes.first.scope&.id %>
+            <% else %>
+              <div class="field">
+                <%= f.select :scope_id,
+                             scopes.map { |scope| [translated_attribute(scope.scope_name), scope&.scope&.id] },
+                             required: true,
+                             include_blank: t(".select_scope") %>
+              </div>
+            <% end %>
+
+            <% if initiative_type.area_enabled? %>
+              <div class="field">
+                <%= f.areas_select :area_id, areas_for_select(current_organization), prompt: t(".select_area") %>
+              </div>
+            <% end %>
+
+            <% if Decidim::UserGroups::ManageableUserGroups.for(current_user).verified.any? %>
+              <div class="field">
+                <%= f.select :decidim_user_group_id,
+                             Decidim::UserGroups::ManageableUserGroups.for(current_user).verified.map { |g| [g.name, g.id] },
+                             include_blank: current_user.name, help_text: t(".decidim_user_group_id_help") %>
+              </div>
+            <% end %>
+
+            <% if initiative_type.attachments_enabled? %>
+              <fieldset class="attachments_container">
+                <legend><%= t("attachment_legend", scope: "decidim.initiatives.form") %></legend>
+
+                <div class="row column">
+                  <%= f.attachment :documents,
+                                   multiple: true,
+                                   label: t("add_attachments", scope: "decidim.initiatives.form") %>
+                </div>
+              </fieldset>
+            <% end %>
+          </div>
+          <div class="actions">
+            <%= f.submit t(".continue"), class: "button expanded", data: { disable_with: true } %>
+          </div>
+        <% end %>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/decidim/initiatives/create_initiative/fill_data.html.erb
+++ b/app/views/decidim/initiatives/create_initiative/fill_data.html.erb
@@ -48,10 +48,6 @@
               <%= text_editor_for(f, :description, lines: 8, toolbar: :content) %>
             </div>
 
-            <div class="field">
-              <%= f.text_field :hashtag %>
-            </div>
-
               <% signature_type_options = signature_type_options(f.object) %>
               <% if signature_type_options.length == 1 %>
                 <%= f.hidden_field :signature_type, value: signature_type_options.first.last %>

--- a/app/views/decidim/initiatives/initiatives/_form.html.erb
+++ b/app/views/decidim/initiatives/initiatives/_form.html.erb
@@ -25,10 +25,6 @@
   <%= text_editor_for(form, :description, toolbar: :content, lines: 8, disabled: !allowed_to?(:update, :initiative, initiative: current_initiative), value: translated_attribute(@form.description)) %>
 </div>
 
-<div class="field">
-  <%= form.text_field :hashtag, disabled: !allowed_to?(:update, :initiative, initiative: current_initiative) %>
-</div>
-
 <% signature_type_options = signature_type_options(form.object) %>
 <% if signature_type_options.length == 1 %>
   <%= form.hidden_field :signature_type, value: signature_type_options.first.last %>
@@ -42,12 +38,6 @@
   </div>
 <% end %>
 
-<div class="field">
-  <%= form.select :scope_id,
-                  @form.available_scopes.map { |scope| [translated_attribute(scope.scope_name), scope&.scope&.id] },
-                  { disabled: !@form.state_updatable? } %>
-</div>
-
 <% if current_initiative.area_enabled? %>
   <div class="field">
     <%= form.areas_select :area_id,
@@ -59,13 +49,6 @@
                           disabled: !@form.area_updatable? %>
   </div>
 <% end %>
-
-<div class="field">
-  <%= form.select :state,
-                  Decidim::Initiative.states.keys.map { |state| [I18n.t(state, scope: "decidim.initiatives.admin_states"), state] },
-                  {},
-                  { disabled: !@form.state_updatable? } %>
-</div>
 
 <% if current_initiative.type.attachments_enabled? %>
   <fieldset class="attachments_container">

--- a/app/views/decidim/initiatives/initiatives/_form.html.erb
+++ b/app/views/decidim/initiatives/initiatives/_form.html.erb
@@ -31,11 +31,9 @@
 
 <% signature_type_options = signature_type_options(form.object) %>
 <% if signature_type_options.length == 1 %>
-  <%= form.hidden_field :signature_type %>
+  <%= form.hidden_field :signature_type, value: signature_type_options.first.last %>
 <% else %>
-  <div class="field">
-    <%= form.select :signature_type, signature_type_options, {}, { disabled: !@form.signature_type_updatable? } %>
-  </div>
+  <%= form.hidden_field :signature_type, value: signature_type_options.last.last %>
 <% end %>
 
 <% if can_edit_custom_signature_end_date?(current_initiative) %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -144,6 +144,8 @@ en:
         initiatives_settings:
           update: "%{user_name} updated the initiatives settings"
       create_initiative:
+        fill_data:
+          decidim_user_group_id_help: Decidim user group id help
         select_initiative_type:
           not_authorized:
             authorizations_page: View authorizations

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -148,6 +148,8 @@ fr:
         initiatives_settings:
           update: "%{user_name} a mis à jour les paramètres d'initiatives"
       create_initiative:
+        fill_data:
+          decidim_user_group_id_help: Il n'est pas possible de changer l'auteur de la pétition après sa création
         select_initiative_type:
           not_authorized:
             authorizations_page: Voir les autorisations

--- a/spec/system/create_initiative_spec.rb
+++ b/spec/system/create_initiative_spec.rb
@@ -1,0 +1,609 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe "Initiative", type: :system do
+  let(:organization) { create(:organization, available_authorizations: authorizations) }
+  let(:do_not_require_authorization) { true }
+  let(:authorizations) { %w(dummy_authorization_handler) }
+  let!(:authorized_user) { create(:user, :confirmed, organization: organization) }
+  let!(:authorization) { create(:authorization, user: authorized_user) }
+  let(:login) { true }
+
+  let(:initiative_type_minimum_committee_members) { 2 }
+  let(:signature_type) { "any" }
+  let(:initiative_type_promoting_committee_enabled) { true }
+  let(:initiative_type) do
+    create(:initiatives_type,
+           organization: organization,
+           minimum_committee_members: initiative_type_minimum_committee_members,
+           promoting_committee_enabled: initiative_type_promoting_committee_enabled,
+           signature_type: signature_type)
+  end
+  let!(:other_initiative_type) { create(:initiatives_type, organization: organization) }
+  let!(:initiative_type_scope) { create(:initiatives_type_scope, type: initiative_type) }
+  let!(:other_initiative_type_scope) { create(:initiatives_type_scope, type: initiative_type) }
+
+  shared_examples "initiatives path redirection" do
+    it "redirects to initiatives path" do
+      accept_confirm do
+        click_link("Send my initiative")
+      end
+
+      expect(page).to have_current_path("/initiatives")
+    end
+  end
+
+  before do
+    switch_to_host(organization.host)
+    login_as(authorized_user, scope: :user) if authorized_user && login
+    visit decidim_initiatives.initiatives_path
+    allow(Decidim::Initiatives.config).to receive(:do_not_require_authorization).and_return(do_not_require_authorization)
+  end
+
+  context "when user visits the initiatives wizard and is not logged in" do
+    let(:login) { false }
+    let(:do_not_require_authorization) { false }
+    let(:signature_type) { "online" }
+
+    context "when there is only one initiative type" do
+      let!(:other_initiative_type) { nil }
+      let!(:other_initiative_type_scope) { nil }
+
+      [
+        :select_initiative_type,
+        :previous_form,
+        :show_similar_initiatives,
+        :fill_data,
+        :promotal_committee,
+        :finish
+      ].each do |step|
+        it "redirects to the login page when landing on #{step}" do
+          expect(Decidim::InitiativesType.count).to eq(1)
+          visit decidim_initiatives.create_initiative_path(step)
+          expect(page).to have_current_path("/users/sign_in")
+        end
+      end
+    end
+
+    context "when there are more initiative types" do
+      [
+        :select_initiative_type,
+        :previous_form,
+        :show_similar_initiatives,
+        :fill_data,
+        :promotal_committee,
+        :finish
+      ].each do |step|
+        it "redirects to the login page when landing on #{step}" do
+          expect(Decidim::InitiativesType.count).to eq(2)
+          visit decidim_initiatives.create_initiative_path(step)
+          expect(page).to have_current_path("/users/sign_in")
+        end
+      end
+    end
+  end
+
+  context "when user requests a page not having all the data required" do
+    let(:do_not_require_authorization) { false }
+    let(:signature_type) { "online" }
+
+    context "when there is only one initiative type" do
+      let!(:other_initiative_type) { nil }
+      let!(:other_initiative_type_scope) { nil }
+
+      [
+        :select_initiative_type,
+        :previous_form,
+        :show_similar_initiatives,
+        :fill_data,
+        :promotal_committee,
+        :finish
+      ].each do |step|
+        it "redirects to the previous_form page when landing on #{step}" do
+          expect(Decidim::InitiativesType.count).to eq(1)
+          visit decidim_initiatives.create_initiative_path(step)
+          expect(page).to have_current_path(decidim_initiatives.create_initiative_path(:previous_form))
+        end
+      end
+    end
+
+    context "when there are more initiative types" do
+      [
+        :previous_form,
+        :show_similar_initiatives,
+        :fill_data,
+        :promotal_committee,
+        :finish
+      ].each do |step|
+        it "redirects to the select_initiative_type page when landing on #{step}" do
+          expect(Decidim::InitiativesType.count).to eq(2)
+          visit decidim_initiatives.create_initiative_path(step)
+          expect(page).to have_current_path(decidim_initiatives.create_initiative_path(:select_initiative_type))
+        end
+      end
+    end
+  end
+
+  describe "create initiative verification" do
+    context "when the user is logged in" do
+      context "and they're verified" do
+        it "they are taken to the initiative form" do
+          click_link "New initiative"
+          expect(page).to have_content("Which initiative do you want to launch")
+        end
+      end
+
+      context "and they aren't verified" do
+        let(:authorization) { nil }
+
+        it "they need to verify" do
+          click_button "New initiative"
+          expect(page).to have_content("Authorization required")
+        end
+
+        it "they are redirected to the initiative form after verifying" do
+          click_button "New initiative"
+          click_link "View authorizations"
+          click_link "Example authorization"
+          fill_in "Document number", with: "123456789X"
+          click_button "Send"
+          expect(page).to have_content("Which initiative do you want to launch")
+        end
+      end
+    end
+
+    context "when they aren't logged in" do
+      let(:login) { false }
+
+      it "they need to login in" do
+        click_button "New initiative"
+        expect(page).to have_content("Please sign in")
+      end
+
+      context "when they are verified" do
+        it "they are redirected to the initiative form after log in" do
+          click_button "New initiative"
+          fill_in "Email", with: authorized_user.email
+          fill_in "Password", with: "decidim123456789"
+          click_button "Log in"
+
+          expect(page).to have_content("Which initiative do you want to launch")
+        end
+      end
+
+      context "when they aren't verified" do
+        let(:do_not_require_authorization) { false }
+        let(:authorization) { nil }
+
+        it "they are shown an error" do
+          click_button "New initiative"
+          fill_in "Email", with: authorized_user.email
+          fill_in "Password", with: "decidim123456789"
+          click_button "Log in"
+
+          expect(page).to have_content("You are not authorized to perform this action")
+        end
+      end
+    end
+  end
+
+  context "when rich text editor is enabled for participants" do
+    let(:initiative_type_minimum_committee_members) { 2 }
+    let(:signature_type) { "any" }
+    let(:initiative_type_promoting_committee_enabled) { true }
+    let(:initiative_type) do
+      create(:initiatives_type,
+             organization: organization,
+             minimum_committee_members: initiative_type_minimum_committee_members,
+             promoting_committee_enabled: initiative_type_promoting_committee_enabled,
+             signature_type: signature_type)
+    end
+    let!(:other_initiative_type) { create(:initiatives_type, organization: organization) }
+    let!(:initiative_type_scope) { create(:initiatives_type_scope, type: initiative_type) }
+    let!(:other_initiative_type_scope) { create(:initiatives_type_scope, type: initiative_type) }
+
+    before do
+      organization.update(rich_text_editor_in_public_views: true)
+      click_link "New initiative"
+      find_button("I want to promote this initiative").click
+    end
+
+    it_behaves_like "having a rich text editor", "new_initiative_previous_form", "content"
+  end
+
+  describe "creating an initiative" do
+    context "without validation" do
+      let(:initiative_type_minimum_committee_members) { 2 }
+      let(:signature_type) { "any" }
+      let(:initiative_type_promoting_committee_enabled) { true }
+      let(:initiative_type) do
+        create(:initiatives_type,
+               organization: organization,
+               minimum_committee_members: initiative_type_minimum_committee_members,
+               promoting_committee_enabled: initiative_type_promoting_committee_enabled,
+               signature_type: signature_type)
+      end
+      let!(:other_initiative_type) { create(:initiatives_type, organization: organization) }
+      let!(:initiative_type_scope) { create(:initiatives_type_scope, type: initiative_type) }
+      let!(:other_initiative_type_scope) { create(:initiatives_type_scope, type: initiative_type) }
+
+      before do
+        click_link "New initiative"
+      end
+
+      context "and select initiative type" do
+        it "offers contextual help" do
+          within ".callout.secondary" do
+            expect(page).to have_content("Initiatives are a means by which the participants can intervene so that the organization can undertake actions in defence of the general interest. Which initiative do you want to launch?")
+          end
+        end
+
+        it "shows the available initiative types" do
+          within "main" do
+            expect(page).to have_content(translated(initiative_type.title, locale: :en))
+            expect(page).to have_content(ActionView::Base.full_sanitizer.sanitize(translated(initiative_type.description, locale: :en), tags: []))
+          end
+        end
+
+        it "do not show initiative types without related scopes" do
+          within "main" do
+            expect(page).not_to have_content(translated(other_initiative_type.title, locale: :en))
+            expect(page).not_to have_content(ActionView::Base.full_sanitizer.sanitize(translated(other_initiative_type.description, locale: :en), tags: []))
+          end
+        end
+      end
+
+      context "and fill basic data" do
+        before do
+          find_button("I want to promote this initiative").click
+        end
+
+        it "has a hidden field with the selected initiative type" do
+          expect(page).to have_xpath("//input[@id='initiative_type_id']", visible: :all)
+          expect(find(:xpath, "//input[@id='initiative_type_id']", visible: :all).value).to eq(initiative_type.id.to_s)
+        end
+
+        it "have fields for title and description" do
+          expect(page).to have_xpath("//input[@id='initiative_title']")
+          expect(page).to have_xpath("//textarea[@id='initiative_description']", visible: :all)
+        end
+
+        it "offers contextual help" do
+          within ".callout.secondary" do
+            expect(page).to have_content("What does the initiative consist of? Write down the title and description. We recommend a short and concise title and a description focused on the proposed solution.")
+          end
+        end
+      end
+
+      context "when there is only one initiative type" do
+        let!(:other_initiative_type) { nil }
+
+        it "doesn't displays initiative types" do
+          expect(page).not_to have_current_path(decidim_initiatives.create_initiative_path(id: :select_initiative_type))
+        end
+
+        it "doesn't display the 'choose' step" do
+          within ".wizard__steps" do
+            expect(page).not_to have_content("Choose")
+          end
+        end
+
+        it "has a hidden field with the selected initiative type" do
+          expect(page).to have_xpath("//input[@id='initiative_type_id']", visible: :all)
+          expect(find(:xpath, "//input[@id='initiative_type_id']", visible: :all).value).to eq(initiative_type.id.to_s)
+        end
+
+        it "have fields for title and description" do
+          expect(page).to have_xpath("//input[@id='initiative_title']")
+          expect(page).to have_xpath("//textarea[@id='initiative_description']", visible: :all)
+        end
+
+        it "offers contextual help" do
+          within ".callout.secondary" do
+            expect(page).to have_content("What does the initiative consist of? Write down the title and description. We recommend a short and concise title and a description focused on the proposed solution.")
+          end
+        end
+      end
+
+      context "when Show similar initiatives" do
+        let!(:initiative) { create(:initiative, organization: organization) }
+
+        before do
+          find_button("I want to promote this initiative").click
+          fill_in "Title", with: translated(initiative.title, locale: :en)
+          fill_in "initiative_description", with: translated(initiative.description, locale: :en)
+          find_button("Continue").click
+        end
+
+        it "similar initiatives view is shown" do
+          expect(page).to have_content("Compare")
+        end
+
+        it "offers contextual help" do
+          within ".callout.secondary" do
+            expect(page).to have_content("If any of the following initiatives is similar to yours we encourage you to sign it. Your proposal will have more possibilities to get done.")
+          end
+        end
+
+        it "contains data about the similar initiative found" do
+          expect(page).to have_content(translated(initiative.title, locale: :en))
+          expect(page).to have_content(ActionView::Base.full_sanitizer.sanitize(translated(initiative.description, locale: :en), tags: []))
+          expect(page).to have_content(translated(initiative.type.title, locale: :en))
+          expect(page).to have_content(translated(initiative.scope.name, locale: :en))
+          expect(page).to have_content(initiative.author_name)
+        end
+      end
+
+      context "when create initiative" do
+        let(:initiative) { build(:initiative) }
+
+        context "when there is only one initiative type" do
+          let!(:other_initiative_type) { nil }
+
+          before do
+            fill_in "Title", with: translated(initiative.title, locale: :en)
+            fill_in "initiative_description", with: translated(initiative.description, locale: :en)
+            find_button("Continue").click
+          end
+
+          it "does not show select input for initiative_type" do
+            expect(page).not_to have_content("Initiative type")
+            expect(page).not_to have_css("#initiative_type_id")
+          end
+
+          it "has a hidden field with the selected initiative type" do
+            expect(page).to have_xpath("//input[@id='initiative_type_id']", visible: :all)
+            expect(find(:xpath, "//input[@id='initiative_type_id']", visible: :all).value).to eq(initiative_type.id.to_s)
+          end
+        end
+
+        context "when there are several initiatives type" do
+          before do
+            find_button("I want to promote this initiative").click
+            fill_in "Title", with: translated(initiative.title, locale: :en)
+            fill_in "initiative_description", with: translated(initiative.description, locale: :en)
+            find_button("Continue").click
+          end
+
+          it "create view is shown" do
+            expect(page).to have_content("Create")
+          end
+
+          it "offers contextual help" do
+            within ".callout.secondary" do
+              expect(page).to have_content("Review the content of your initiative. Is your title easy to understand? Is the objective of your initiative clear?")
+              expect(page).to have_content("You have to choose the type of signature. In-person, online or a combination of both")
+              expect(page).to have_content("Which is the geographic scope of the initiative?")
+            end
+          end
+
+          it "shows select input for initiative_type" do
+            expect(page).to have_content("Type")
+            expect(find(:xpath, "//select[@id='initiative_type_id']", visible: :all).value).to eq(initiative_type.id.to_s)
+          end
+
+          it "shows information collected in previous steps already filled" do
+            expect(find(:xpath, "//input[@id='initiative_title']").value).to eq(translated(initiative.title, locale: :en))
+            expect(find(:xpath, "//textarea[@id='initiative_description']", visible: :all).value).to eq(translated(initiative.description, locale: :en))
+          end
+
+          it "shows input for signature collection type" do
+            expect(page).to have_content("Signature collection type")
+            expect(find(:xpath, "//select[@id='initiative_signature_type']", visible: :all).value).to eq("online")
+          end
+
+          it "shows input for hashtag" do
+            expect(page).to have_content("Hashtag")
+            expect(find(:xpath, "//input[@id='initiative_hashtag']", visible: :all).value).to eq("")
+          end
+
+          context "when only one signature collection and scope are available" do
+            let(:other_initiative_type_scope) { nil }
+            let(:initiative_type) { create(:initiatives_type, organization: organization, minimum_committee_members: initiative_type_minimum_committee_members, signature_type: "offline") }
+
+            it "hides and automatically selects the values" do
+              expect(page).not_to have_content("Signature collection type")
+              expect(page).not_to have_content("Scope")
+              expect(find(:xpath, "//select[@id='initiative_type_id']", visible: :all).value).to eq(initiative_type.id.to_s)
+              expect(find(:xpath, "//input[@id='initiative_signature_type']", visible: :all).value).to eq("offline")
+            end
+          end
+
+          context "when the scope isn't selected" do
+            it "shows an error" do
+              select("Online", from: "Signature collection type")
+              find_button("Continue").click
+              expect(page).to have_content("There's an error in this field")
+            end
+          end
+
+          context "when the initiative type does not enable custom signature end date" do
+            it "does not show the signature end date" do
+              expect(page).not_to have_content("End of signature collection period")
+            end
+          end
+
+          context "when the initiative type enables custom signature end date" do
+            let(:initiative_type) { create(:initiatives_type, :custom_signature_end_date_enabled, organization: organization, minimum_committee_members: initiative_type_minimum_committee_members, signature_type: "offline") }
+
+            it "shows the signature end date" do
+              expect(page).to have_content("End of signature collection period")
+            end
+          end
+
+          context "when the initiative type does not enable area" do
+            it "does not show the area" do
+              expect(page).not_to have_content("Area")
+            end
+          end
+
+          context "when the initiative type enables area" do
+            let(:initiative_type) { create(:initiatives_type, :area_enabled, organization: organization, minimum_committee_members: initiative_type_minimum_committee_members, signature_type: "offline") }
+
+            it "shows the area" do
+              expect(page).to have_content("Area")
+            end
+          end
+
+          context "when rich text editor is enabled for participants" do
+            before do
+              expect(page).to have_content("Create")
+              organization.update(rich_text_editor_in_public_views: true)
+
+              visit current_path
+            end
+
+            it_behaves_like "having a rich text editor", "new_initiative_form", "content"
+          end
+        end
+      end
+
+      context "when there's a promoter committee" do
+        let(:initiative) { build(:initiative, organization: organization, scoped_type: initiative_type_scope) }
+
+        before do
+          expect(page).to have_content("I want to promote this initiative")
+          find_button("I want to promote this initiative").click
+
+          fill_in "Title", with: translated(initiative.title, locale: :en)
+          fill_in "initiative_description", with: translated(initiative.description, locale: :en)
+          find_button("Continue").click
+
+          select("Online", from: "Signature collection type")
+          select(translated(initiative_type_scope.scope.name, locale: :en), from: "Scope")
+          find_button("Continue").click
+        end
+
+        it "shows the promoter committee" do
+          expect(page).to have_content("Promoter committee")
+        end
+
+        it "offers contextual help" do
+          within ".callout.secondary" do
+            expect(page).to have_content("This kind of initiative requires a Promoting Commission consisting of at least #{initiative_type_minimum_committee_members} people (attestors). You must share the following link with the other people that are part of this initiative. When your contacts receive this link they will have to follow the indicated steps.")
+          end
+        end
+
+        it "contains a link to invite other users" do
+          expect(page).to have_content("/committee_requests/new")
+        end
+
+        it "contains a button to continue with next step" do
+          expect(page).to have_content("Continue")
+        end
+
+        context "when minimum committee size is zero" do
+          let(:initiative_type_minimum_committee_members) { 0 }
+
+          it "skips to next step" do
+            within(".step--active") do
+              expect(page).not_to have_content("Promoter committee")
+              expect(page).to have_content("Finish")
+            end
+          end
+        end
+
+        context "and it's disabled at the type scope" do
+          let(:initiative_type) { create(:initiatives_type, organization: organization, promoting_committee_enabled: false, signature_type: signature_type) }
+
+          it "skips the promoting committee settings" do
+            expect(page).not_to have_content("Promoter committee")
+            expect(page).to have_content("Finish")
+          end
+        end
+      end
+
+      context "when finish" do
+        let(:initiative) { build(:initiative) }
+
+        before do
+          find_button("I want to promote this initiative").click
+
+          fill_in "Title", with: translated(initiative.title, locale: :en)
+          fill_in "initiative_description", with: translated(initiative.description, locale: :en)
+          find_button("Continue").click
+
+          select(translated(initiative_type_scope.scope.name, locale: :en), from: "Scope")
+          select("Online", from: "Signature collection type")
+          dynamically_attach_file(:initiative_documents, Decidim::Dev.asset("Exampledocument.pdf"))
+          find_button("Continue").click
+        end
+
+        it "shows the page component" do
+          find_link("Continue").click
+          find_link("Edit my initiative").click
+
+          within ".process-nav__content" do
+            find_link("Page").click
+          end
+
+          expect(page).to have_content("PAGE")
+        end
+
+        context "when minimum committee size is above zero" do
+          before do
+            find_link("Continue").click
+          end
+
+          it "finish view is shown" do
+            expect(page).to have_content("Finish")
+          end
+
+          it "Offers contextual help" do
+            within ".callout.secondary" do
+              expect(page).to have_content("Congratulations! Your initiative has been successfully created.")
+            end
+          end
+
+          it "displays an edit link" do
+            within ".actions" do
+              expect(page).to have_link("Edit my initiative")
+            end
+          end
+
+          it "displays a link to take the user to their initiatives" do
+            within ".actions" do
+              expect(page).to have_link("Go to my initiatives")
+              find_link("Go to my initiatives").click
+            end
+
+            expect(page).to have_content(translated(initiative.title, locale: :en))
+          end
+        end
+
+        context "when minimum committee size is zero" do
+          let(:initiative) { build(:initiative, organization: organization, scoped_type: initiative_type_scope) }
+          let(:initiative_type_minimum_committee_members) { 0 }
+
+          it "displays a send to technical validation link" do
+            expected_message = "You are going to send the initiative for an admin to review it and publish it. Once published you will not be able to edit it. Are you sure?"
+            within ".actions" do
+              expect(page).to have_link("Send my initiative")
+              expect(page).to have_selector "a[data-confirm='#{expected_message}']"
+            end
+          end
+
+          it_behaves_like "initiatives path redirection"
+        end
+
+        context "when promoting committee is not enabled" do
+          let(:initiative) { build(:initiative, organization: organization, scoped_type: initiative_type_scope) }
+          let(:initiative_type_promoting_committee_enabled) { false }
+          let(:initiative_type_minimum_committee_members) { 0 }
+
+          expected_message = "You are going to send the initiative for an admin to review it and publish it. Once published you will not be able to edit it. Are you sure?"
+
+          it "displays a send to technical validation link" do
+            within ".actions" do
+              expect(page).to have_link("Send my initiative")
+              expect(page).to have_selector "a[data-confirm='#{expected_message}']"
+            end
+          end
+
+          it_behaves_like "initiatives path redirection"
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
#### :tophat: Description
This PR aims to remove when creating or editing an initiative:

- the initiative signature type field 
- the hashtag field
- the scope field

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to https://github.com/OpenSourcePolitics/decidim-cd44/pull/38
- [Notion card](https://www.notion.so/opensourcepolitics/CD44-Recette-0-27-85ea99ba58d44ddba0ab16a187835e91?pvs=4)

#### Testing
1. Create an initiative type with mixed signature 
2. Create an initiative with this type
3. At the fill_data step, see that the signature type field is not displayed

#### Tasks
- [x] Add specs
- [ ] Add note about overrides in OVERLOADS.md
- [ ] In case of new dependencies or version bump, update related documentation

### :camera: Screenshots
<img width="615" alt="Capture d’écran 2023-09-21 à 12 14 23" src="https://github.com/OpenSourcePolitics/decidim-cd44/assets/52420208/d3127a39-6342-4403-b885-6ce037191ffa">


