### PR TITLE
fix: Fix Display of Budgets Summary

### DIFF
--- a/OVERLOADS.md
+++ b/OVERLOADS.md
@@ -1,6 +1,9 @@
 # Overrides
 ## Fixes
 
+### bf363e7 - fix: Fix Display of Budgets Summary (#123), 2023-09-21
+* `app/views/decidim/budgets/projects/_order_progress.html.erb`
+
 ### 28c8d74 - Add basic tests to reference package (#1), 2021-07-26
 * `lib/extends/commands/decidim/admin/create_participatory_space_private_user_extends.rb`
 * `lib/extends/commands/decidim/admin/impersonate_user_extends.rb`

--- a/app/views/decidim/budgets/projects/_order_progress.html.erb
+++ b/app/views/decidim/budgets/projects/_order_progress.html.erb
@@ -1,0 +1,58 @@
+<div id="order-progress">
+  <div class="budget-summary__progressbox" data-current-allocation="<%= current_order ? current_order.total : 0 %>">
+    <div class="progress budget-progress" role="progressbar" aria-valuenow="<%= current_order_budget_percent %>" aria-valuetext="<%= current_order_budget_percent %>%" aria-valuemin="0" aria-valuemax="100">
+      <div class="progress-meter progress-meter--minimum" style="width: <%= current_order_budget_percent_minimum %>%"></div>
+      <!--Change width and text dynamically.-->
+      <div class="progress-meter budget-progress__meter" style="width: <%= current_order_budget_percent %>%">
+        <span class="progress-meter-text progress-meter-text--right"><%= current_order_budget_percent %>%</span>
+      </div>
+    </div>
+    <% if !current_order_checked_out? && voting_open? %>
+      <button class="button small button--sc" data-toggle="budget-confirm" <%= budget_confirm_disabled_attr %>>
+        <%= voting_booth_forced? ? t(".vote") : t(".ready") %>
+      </button>
+    <% end %>
+  </div>
+
+  <div class="progressbox-fixed-wrapper" data-progressbox-fixed>
+    <div class="budget-summary__progressbox budget-summary__progressbox--fixed padding-bottom-0">
+      <% if current_order.projects_rule? %>
+        <span class="mini-title">
+          <strong>
+            <%= t(".assigned") %>
+            <%= render partial: "order_total_budget" %>
+          </strong>
+        </span>
+      <% else %>
+        <div class="budget-summary__total" data-total-allocation="<%= current_order.available_allocation %>" data-total-budget="<%= budget.total_budget %>">
+          <span class="mini-title"><%= t(".total_budget") %>
+            <strong class="mini-title__strong mini-title__strong--highlight">
+              <%= budget_to_currency(budget.total_budget) %>
+            </strong>
+          </span>
+        </div>
+      <% end %>
+    </div>
+    <div class="budget-summary__progressbox budget-summary__progressbox--fixed">
+      <div class="progress budget-progress budget-progress--fixed" role="progressbar" aria-valuenow="<%= current_order_budget_percent %>" aria-valuetext="<%= current_order_budget_percent %>%" aria-valuemin="0" aria-valuemax="100">
+        <div class="progress-meter progress-meter--minimum" style="width: <%= current_order_budget_percent_minimum %>%"></div>
+        <div class="progress-meter budget-progress__meter" style="width: <%= current_order_budget_percent %>%">
+          <span class="progress-meter-text progress-meter-text--right"><%= current_order_budget_percent %>%</span>
+        </div>
+      </div>
+      <% if !current_order_checked_out? && voting_open? %>
+        <button class="button small button--sc" data-toggle="budget-confirm" <%= budget_confirm_disabled_attr %>>
+          <%= t(".vote") %>
+        </button>
+      <% end %>
+    </div>
+    <% unless current_order.projects_rule? %>
+      <div class="budget-summary__progressbox--fixed padding-top-0">
+        <span class="mini-title">
+          <%= t(".assigned") %>
+          <%= render partial: "order_total_budget" %>
+        </span>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -110,6 +110,12 @@ en:
             category: Category
             id: Id
             title: Title
+      projects:
+        order_progress:
+          assigned: 'Assigned: '
+          ready: I am ready
+          total_budget: 'Total budget: '
+          vote: Vote
     budgets_importer:
       actions:
         import: Importer des projets

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -110,6 +110,12 @@ fr:
             category: Category
             id: Id
             title: Title
+      projects:
+        order_progress:
+          assigned: 'Assigné: '
+          ready: I am ready
+          total_budget: 'Total budget: '
+          vote: Vote
     budgets_importer:
       actions:
         import: Importer des projets


### PR DESCRIPTION
#### :tophat: Description
Fix the display of budgets summary to match the rule of our budgets

#### :pushpin: Related Issues
- [Notion card](https://www.notion.so/opensourcepolitics/CD44-Recette-0-27-85ea99ba58d44ddba0ab16a187835e91?pvs=4)

#### Tasks
- [ ] Override file to add a new condition
- [ ] Add note about overrides in OVERLOADS.md
