### PR TITLE
fix: Add initiatives initializer backport

### DIFF
--- a/config/initializers/decidim_initiatives.rb
+++ b/config/initializers/decidim_initiatives.rb
@@ -1,43 +1,11 @@
 # frozen_string_literal: true
 
+require "decidim_app/decidim_initiatives"
+
+# Required to define the Decidim::Initiatives configurations
+DecidimApp::DecidimInitiatives.apply_configuration if DecidimApp::DecidimInitiatives.decidim_initiatives_enabled?
+
 if defined?(Decidim::Initiatives)
-  Decidim::Initiatives.configure do |config|
-    # Public Setting that defines the similarity minimum value to consider two
-    # initiatives similar. Defaults to 0.25.
-    config.similarity_threshold = 100
-    config.do_not_require_authorization = true
-    # Public Setting that defines how many similar initiatives will be shown.
-    # Defaults to 5.
-    config.similarity_limit = 0
-
-    # Minimum number of committee members required to pass the initiative to
-    # technical validation phase. Only applies to initiatives created by
-    # individuals.
-    config.minimum_committee_members = 0
-
-    # Number of days available to collect supports after an initiative has been
-    # published.
-    config.default_signature_time_period_length = 12.months
-
-    # Components enabled for a new initiative
-    config.default_components = []
-
-    # Print functionality enabled. Allows the user to get
-    # a printed version of the initiative from the administration
-    # panel.
-    config.print_enabled = false
-
-    # Set a service to generate a timestamp on each vote. The
-    # attribute is the name of a class whose instances are
-    # initialized with a string containing the data to be
-    # timestamped and respond to a timestamp method
-    config.timestamp_service = "Decidim::Initiatives::UtcTimestamp"
-
-    config.creation_enabled = true
-    config.face_to_face_voting_allowed = true
-    config.online_voting_allowed = true
-  end
-
   Decidim::Initiatives::AdminEngine.routes do
     resources :initiatives_settings, only: [:edit, :update], controller: "initiatives_settings"
   end

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -14,6 +14,19 @@ default: &default
   asset_host: <%= ENV["ASSET_HOST"] %>
   decidim:
     currency: <%= ENV["CURRENCY"] || "€" %>
+    initiatives:
+      creation_enabled: <%= ENV.fetch("INITIATIVES_CREATION_ENABLED", "auto").to_s %>
+      similarity_threshold: <%= ENV.fetch("INITIATIVES_SIMILARITY_THRESHOLD", 0.25).to_f %>
+      similarity_limit: <%= ENV.fetch("INITIATIVES_SIMILARITY_LIMIT", 5).to_i %>
+      minimum_committee_members: <%= ENV.fetch("INITIATIVES_MINIMUM_COMMITTEE_MEMBERS", 2).to_i %>
+      default_signature_time_period_length: <%= ENV.fetch("INITIATIVES_DEFAULT_SIGNATURE_TIME_PERIOD_LENGTH", 120).to_i %>
+      default_components: <%= ENV.fetch("INITIATIVES_DEFAULT_COMPONENTS", "pages, meetings").split(",").to_json %>
+      first_notification_percentage: <%= ENV.fetch("INITIATIVES_FIRST_NOTIFICATION_PERCENTAGE", 33).to_i %>
+      second_notification_percentage: <%= ENV.fetch("INITIATIVES_SECOND_NOTIFICATION_PERCENTAGE", 66).to_i %>
+      stats_cache_expiration_time: <%= ENV.fetch("INITIATIVES_STATS_CACHE_EXPIRATION_TIME", 5).to_i %>
+      max_time_in_validating_state: <%= ENV.fetch("INITIATIVES_MAX_TIME_IN_VALIDATING_STATE", 60).to_i %>
+      print_enabled: <%= ENV.fetch("INITIATIVES_PRINT_ENABLED", "auto").to_s %>
+      do_not_require_authorization: <%= ENV.fetch("INITIATIVES_DO_NOT_REQUIRE_AUTHORIZATION", "auto").to_s %>
     expire_session_after: <%= ENV["EXPIRE_SESSION_AFTER"] %>
     rack_attack:
       enabled: <%= ENV["ENABLE_RACK_ATTACK"]&.to_i || 1 %>

--- a/lib/decidim_app/decidim_initiatives.rb
+++ b/lib/decidim_app/decidim_initiatives.rb
@@ -1,0 +1,81 @@
+# frozen_string_literal: true
+
+module DecidimApp
+  class DecidimInitiatives
+    def self.decidim_initiatives_enabled?
+      defined?(Decidim::Initiatives)
+    end
+
+    def self.apply_configuration
+      Decidim::Initiatives.configure do |c|
+        c.creation_enabled = creation_enabled? unless Rails.application.secrets.dig(:decidim, :initiatives, :creation_enabled) == "auto"
+        c.similarity_threshold = similarity_threshold
+        c.similarity_limit = similarity_limit
+        c.minimum_committee_members = minimum_committee_members
+        c.default_signature_time_period_length = default_signature_time_period_length
+        c.default_components = default_components
+        c.first_notification_percentage = first_notification_percentage
+        c.second_notification_percentage = second_notification_percentage
+        c.stats_cache_expiration_time = stats_cache_expiration_time
+        c.max_time_in_validating_state = max_time_in_validating_state
+        c.print_enabled = print_enabled? unless Rails.application.secrets.dig(:decidim, :initiatives, :print_enabled) == "auto"
+        c.do_not_require_authorization = do_not_require_authorization? unless Rails.application.secrets.dig(:decidim, :initiatives, :do_not_require_authorization) == "auto"
+      end
+    end
+
+    def self.creation_enabled?
+      Rails.application.secrets.dig(:decidim, :initiatives, :creation_enabled).present?
+    end
+
+    def self.similarity_threshold
+      Rails.application.secrets.dig(:decidim, :initiatives, :similarity_threshold).presence || 0.25
+    end
+
+    def self.similarity_limit
+      Rails.application.secrets.dig(:decidim, :initiatives, :similarity_limit).presence || 5
+    end
+
+    def self.minimum_committee_members
+      Rails.application.secrets.dig(:decidim, :initiatives, :minimum_committee_members).presence || 2
+    end
+
+    def self.default_signature_time_period_length
+      Rails.application.secrets.dig(:decidim, :initiatives, :default_signature_time_period_length).presence || 120
+    end
+
+    # When INITIATIVES_DEFAULT_COMPONENTS=[]
+    # Value is : ["[]"]
+    # We must prevent this
+    def self.default_components
+      if Rails.application.secrets.dig(:decidim, :initiatives, :default_components) == ["[]"]
+        []
+      else
+        Rails.application.secrets.dig(:decidim, :initiatives, :default_components)
+      end
+    end
+
+    def self.first_notification_percentage
+      Rails.application.secrets.dig(:decidim, :initiatives, :first_notification_percentage).presence || 33
+    end
+
+    def self.second_notification_percentage
+      Rails.application.secrets.dig(:decidim, :initiatives, :second_notification_percentage).presence || 66
+    end
+
+    def self.stats_cache_expiration_time
+      Rails.application.secrets.dig(:decidim, :initiatives, :stats_cache_expiration_time).minutes
+    end
+
+    def self.max_time_in_validating_state
+      Rails.application.secrets.dig(:decidim, :initiatives, :max_time_in_validating_state).days
+    end
+
+    def self.print_enabled?
+      Rails.application.secrets.dig(:decidim, :initiatives, :print_enabled).present?
+    end
+
+    def self.do_not_require_authorization?
+      Rails.application.secrets.dig(:decidim, :initiatives, :do_not_require_authorization).present?
+    end
+  end
+end

--- a/spec/lib/decidim_app/decidim_initiatives_spec.rb
+++ b/spec/lib/decidim_app/decidim_initiatives_spec.rb
@@ -1,0 +1,199 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe DecidimApp::DecidimInitiatives do
+  subject { described_class }
+
+  describe "#creation_enabled?" do
+    it "returns true" do
+      expect(subject).to be_creation_enabled
+    end
+
+    context "when 'auto'" do
+      before do
+        allow(Rails.application.secrets).to receive(:dig).with(:decidim, :initiatives, :creation_enabled).and_return("auto")
+      end
+
+      it "returns true" do
+        expect(subject).to be_creation_enabled
+      end
+    end
+
+    context "when empty" do
+      before do
+        allow(Rails.application.secrets).to receive(:dig).with(:decidim, :initiatives, :creation_enabled).and_return("")
+      end
+
+      it "returns false" do
+        expect(subject).not_to be_creation_enabled
+      end
+    end
+  end
+
+  describe "#similarity_threshold" do
+    context "when rails secret '75.0'" do
+      before do
+        allow(Rails.application.secrets).to receive(:dig).with(:decidim, :initiatives, :similarity_threshold).and_return(75.0)
+      end
+
+      it "returns 75.0" do
+        expect(subject.similarity_threshold).to eq(75.0)
+      end
+    end
+  end
+
+  describe "#similarity_limit" do
+    context "when rails secret '50'" do
+      before do
+        allow(Rails.application.secrets).to receive(:dig).with(:decidim, :initiatives, :similarity_limit).and_return(50)
+      end
+
+      it "returns 5" do
+        expect(subject.similarity_limit).to eq(50)
+      end
+    end
+
+    context "when empty returns default" do
+      before do
+        allow(Rails.application.secrets).to receive(:dig).with(:decidim, :initiatives, :similarity_limit).and_return("")
+      end
+
+      it "returns 5" do
+        expect(subject.similarity_limit).to eq(5)
+      end
+    end
+  end
+
+  describe "#minimum_committee_members" do
+    context "when rails secret '365'" do
+      before do
+        allow(Rails.application.secrets).to receive(:dig).with(:decidim, :initiatives, :minimum_committee_members).and_return(365)
+      end
+
+      it "returns 365" do
+        expect(subject.minimum_committee_members).to eq(365)
+      end
+    end
+
+    context "when empty returns default" do
+      before do
+        allow(Rails.application.secrets).to receive(:dig).with(:decidim, :initiatives, :minimum_committee_members).and_return("")
+      end
+
+      it "returns 2" do
+        expect(subject.minimum_committee_members).to eq(2)
+      end
+    end
+  end
+
+  describe "#default_signature_time_period_length" do
+    context "when rails secret '60'" do
+      before do
+        allow(Rails.application.secrets).to receive(:dig).with(:decidim, :initiatives, :default_signature_time_period_length).and_return(60)
+      end
+
+      it "returns 60" do
+        expect(subject.default_signature_time_period_length).to eq(60)
+      end
+    end
+
+    context "when empty returns default" do
+      before do
+        allow(Rails.application.secrets).to receive(:dig).with(:decidim, :initiatives, :default_signature_time_period_length).and_return("")
+      end
+
+      it "returns 120" do
+        expect(subject.default_signature_time_period_length).to eq(120)
+      end
+    end
+  end
+
+  describe "#first_notification_percentage" do
+    context "when rails secret '25'" do
+      before do
+        allow(Rails.application.secrets).to receive(:dig).with(:decidim, :initiatives, :first_notification_percentage).and_return(25)
+      end
+
+      it "returns 25" do
+        expect(subject.first_notification_percentage).to eq(25)
+      end
+    end
+
+    context "when empty returns default" do
+      before do
+        allow(Rails.application.secrets).to receive(:dig).with(:decidim, :initiatives, :first_notification_percentage).and_return("")
+      end
+
+      it "returns 33" do
+        expect(subject.first_notification_percentage).to eq(33)
+      end
+    end
+  end
+
+  describe "#second_notification_percentage" do
+    context "when rails secret '25'" do
+      before do
+        allow(Rails.application.secrets).to receive(:dig).with(:decidim, :initiatives, :second_notification_percentage).and_return(25)
+      end
+
+      it "returns 25" do
+        expect(subject.second_notification_percentage).to eq(25)
+      end
+    end
+
+    context "when empty returns default" do
+      before do
+        allow(Rails.application.secrets).to receive(:dig).with(:decidim, :initiatives, :second_notification_percentage).and_return("")
+      end
+
+      it "returns 66" do
+        expect(subject.second_notification_percentage).to eq(66)
+      end
+    end
+  end
+
+  describe "#stats_cache_expiration_time" do
+    context "when rails secret '25'" do
+      before do
+        allow(Rails.application.secrets).to receive(:dig).with(:decidim, :initiatives, :stats_cache_expiration_time).and_return(25)
+      end
+
+      it "returns 25 minutes" do
+        expect(subject.stats_cache_expiration_time).to eq(25.minutes)
+      end
+    end
+
+    context "when empty returns default" do
+      before do
+        allow(Rails.application.secrets).to receive(:dig).with(:decidim, :initiatives, :stats_cache_expiration_time).and_return(5)
+      end
+
+      it "returns 5 minutes" do
+        expect(subject.stats_cache_expiration_time).to eq(5.minutes)
+      end
+    end
+  end
+
+  describe "#max_time_in_validating_state" do
+    context "when rails secret '25'" do
+      before do
+        allow(Rails.application.secrets).to receive(:dig).with(:decidim, :initiatives, :max_time_in_validating_state).and_return(25)
+      end
+
+      it "returns 25 days" do
+        expect(subject.max_time_in_validating_state).to eq(25.days)
+      end
+    end
+
+    context "when empty returns default" do
+      before do
+        allow(Rails.application.secrets).to receive(:dig).with(:decidim, :initiatives, :max_time_in_validating_state).and_return(60)
+      end
+
+      it "returns 60 days" do
+        expect(subject.max_time_in_validating_state).to eq(60.days)
+      end
+    end
+  end
+end


### PR DESCRIPTION
#### :tophat: Description
Env var are not applied for initiatives configuration

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to https://github.com/OpenSourcePolitics/decidim-app/pull/436?
- [Notion card](https://www.notion.so/opensourcepolitics/CD44-Recette-0-27-85ea99ba58d44ddba0ab16a187835e91?pvs=4)

## Done

- [x] Add Decidim::Initiatives initializers for configurations
- [x] Add Rails Secrets
- [x]  Add specs on `Decidim::App::DecidimInitiatives`


Env variables

```
INITIATIVES_CREATION_ENABLED", "auto"
INITIATIVES_SIMILARITY_THRESHOLD", 0.25
INITIATIVES_SIMILARITY_LIMIT", 5
INITIATIVES_MINIMUM_COMMITTEE_MEMBERS", 2
INITIATIVES_DEFAULT_SIGNATURE_TIME_PERIOD_LENGTH", 120
INITIATIVES_DEFAULT_COMPONENTS", "pages, meetings"
INITIATIVES_FIRST_NOTIFICATION_PERCENTAGE", 33
INITIATIVES_SECOND_NOTIFICATION_PERCENTAGE", 66
INITIATIVES_STATS_CACHE_EXPIRATION_TIME", 5
INITIATIVES_MAX_TIME_IN_VALIDATING_STATE", 60
INITIATIVES_PRINT_ENABLED", "auto"
INITIATIVES_DO_NOT_REQUIRE_AUTHORIZATION", "auto"
```