### PR TITLE
Fix: partial not working for order total budget

### DIFF
--- a/app/views/decidim/budgets/projects/_order_progress.html.erb
+++ b/app/views/decidim/budgets/projects/_order_progress.html.erb
@@ -20,7 +20,7 @@
         <span class="mini-title">
           <strong>
             <%= t(".assigned") %>
-            <%= render partial: "order_total_budget" %>
+            <%= render partial: "decidim/budgets/projects/order_total_budget" %>
           </strong>
         </span>
       <% else %>
@@ -50,7 +50,7 @@
       <div class="budget-summary__progressbox--fixed padding-top-0">
         <span class="mini-title">
           <%= t(".assigned") %>
-          <%= render partial: "order_total_budget" %>
+          <%= render partial: "decidim/budgets/projects/order_total_budget" %>
         </span>
       </div>
     <% end %>


### PR DESCRIPTION
#### :tophat: Description
When trying to add a vote or remove a vote on my order, the counter is not implemented. 

#### Testing
* Start a vote in voting booth
* Add a vote to your order
* See that it's working

#### Tasks
- [ ] Add specs
- [ ] Add note about overrides in OVERLOADS.md
- [ ] In case of new dependencies or version bump, update related documentation

### :camera: Screenshots
<img width="1512" alt="Capture d’écran 2023-09-22 à 12 51 35" src="https://github.com/OpenSourcePolitics/decidim-cd44/assets/52420208/11fa3e04-4520-493e-88b4-2dbdeccef59f">

```
ActionView::Template::Error (Missing partial decidim/budgets/line_items/_order_total_budget, decidim/budgets/application/_order_total_budget, decidim/components/base/_order_total_budget, decidim/application/_order_total_budget, decidim/_order_total_budget, application/_order_total_budget with {:locale=>[:en], :formats=>[:js, :html], :variants=>[], :handlers=>[:raw, :erb, :html, :builder, :ruby]}. Searched in:
  * "/Users/pops/www/OpenSourcePolitics:decidim/decidim-cd44/app/views"
```
```
    50:       <div class="budget-summary__progressbox--fixed padding-top-0">
    51:         <span class="mini-title">
    52:           <%= t(".assigned") %>
    53:           <%= render partial: "order_total_budget" %>
    54:         </span>
    55:       </div>
    56:     <% end %>
```
