### PR TITLE
fix: config for the Object Storage URL path builder

### DIFF
--- a/.env-example
+++ b/.env-example
@@ -38,3 +38,15 @@ THROTTLING_PERIOD=60
 # FRIENDLY_SIGNUP_USE_CONFIRMATION_CODES=
 # SKIP_FIRST_LOGIN_AUTHORIZATION=
 
+# SCALEWAY_ID - String - required if Active Storage use Scaleway as storage service
+SCALEWAY_ID=
+# SCALEWAY_TOKEN - String - required if SCALEWAY_ID is set
+SCALEWAY_TOKEN=
+# SCALEWAY_BUCKET_NAME - String - required if SCALEWAY_ID is set
+SCALEWAY_BUCKET_NAME=
+# SCALEWAY_REGION - String - optional - default to "fr-par" - set the scaleway storage region
+SCALEWAY_REGION=
+# OBJECTSTORE_S3_HOST - String - optional - default to "s3.fr-par.scw.cloud" - set the object storage endpoint
+OBJECTSTORE_S3_HOST=
+# OBJECTSTORE_S3_FORCE_PATH_STYLE - String - optional - default to "true" - When set to true, the bucket name is always left in the request URI and never moved to the host as a sub-domain
+OBJECTSTORE_S3_FORCE_PATH_STYLE=

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -34,7 +34,7 @@ Rails.application.configure do
   config.action_mailer.delivery_method = :letter_opener_web
   config.action_mailer.default_url_options = { port: 3000 }
   # Store uploaded files on the local file system (see config/storage.yml for options)
-  config.active_storage.service = :local
+  config.active_storage.service = Rails.application.secrets.dig(:scaleway, :id).blank? ? :local : :scaleway
 
   config.action_mailer.perform_caching = false
 

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -40,7 +40,9 @@ default: &default
     id: <%= ENV["SCALEWAY_ID"] %>
     token: <%= ENV["SCALEWAY_TOKEN"] %>
     bucket_name: <%= ENV["SCALEWAY_BUCKET_NAME"] %>
+    region: <%= ENV.fetch("SCALEWAY_REGION", "fr-par") %>
     endpoint: <%= ENV.fetch("OBJECTSTORE_S3_HOST", "s3.fr-par.scw.cloud") %>
+    force_path_style: <%= ENV.fetch("OBJECTSTORE_S3_FORCE_PATH_STYLE", "true") %>
   helpscout:
     user:
       main: <%= ENV["HELP_SCOUT_BEACON_USER_SIDE_ID_MAIN"] %>

--- a/config/storage.yml
+++ b/config/storage.yml
@@ -11,8 +11,9 @@ scaleway:
   endpoint: https://<%= Rails.application.secrets.dig(:scaleway, :endpoint) %>
   access_key_id: <%= Rails.application.secrets.dig(:scaleway, :id) %>
   secret_access_key: <%= Rails.application.secrets.dig(:scaleway, :token) %>
-  region: fr-par
+  region: <%= Rails.application.secrets.dig(:scaleway, :region) %>
   bucket: <%= Rails.application.secrets.dig(:scaleway, :bucket_name) %>
+  force_path_style: <%= Rails.application.secrets.dig(:scaleway, :force_path_style) %>
 
 # Use rails credentials:edit to set the AWS secrets (as aws:access_key_id|secret_access_key)
 # amazon:


### PR DESCRIPTION
Add a new parameter to force the bucket name in the path instead of a sub domain : 
- in path : `storage.service.domain/bucket`
- in domain : `bucket.storage.service.domain`