### PR TITLE
feat: Allow to override admin password configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -88,3 +88,5 @@ git-status.txt
 yarn-debug.log*
 .yarn-integrity
 app/compiled_views/
+
+.DS_Store

--- a/config/initializers/decidim.rb
+++ b/config/initializers/decidim.rb
@@ -6,7 +6,15 @@ Decidim.configure do |config|
   config.application_name = "Loire Atlantique"
   config.mailer_sender = "Loire Atlantique <ne-pas-repondre@opensourcepolitics.eu>"
   config.expire_session_after = ENV.fetch("DECIDIM_SESSION_TIMEOUT", 180).to_i.minutes
-  config.admin_password_expiration_days = ENV.fetch("ADMIN_PASSWORD_EXPIRATION_DAYS", 365).to_i.days
+
+  # Admin admin password configurations
+  Rails.application.secrets.dig(:decidim, :admin_password, :strong).tap do |strong_pw|
+    # When the strong password is not configured, default to true
+    config.admin_password_strong = strong_pw.nil? ? true : strong_pw.present?
+  end
+  config.admin_password_expiration_days = Rails.application.secrets.dig(:decidim, :admin_password, :expiration_days)
+  config.admin_password_min_length = Rails.application.secrets.dig(:decidim, :admin_password, :min_length)
+  config.admin_password_repetition_times = Rails.application.secrets.dig(:decidim, :admin_password, :repetition_times)
 
   # Change these lines to set your preferred locales
   if Rails.env.production?

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -13,6 +13,11 @@
 default: &default
   asset_host: <%= ENV["ASSET_HOST"] %>
   decidim:
+    admin_password:
+      expiration_days: <%= ENV.fetch("DECIDIM_ADMIN_PASSWORD_EXPIRATION_DAYS", 365).to_i %>
+      min_length: <%= ENV.fetch("DECIDIM_ADMIN_PASSWORD_MIN_LENGTH", 15).to_i %>
+      repetition_times: <%= ENV.fetch("DECIDIM_ADMIN_PASSWORD_REPETITION_TIMES", 5).to_i %>
+      strong: <%= ENV.fetch("DECIDIM_ADMIN_PASSWORD_STRONG", "false").to_s %>
     currency: <%= ENV["CURRENCY"] || "€" %>
     initiatives:
       creation_enabled: <%= ENV.fetch("INITIATIVES_CREATION_ENABLED", "auto").to_s %>


### PR DESCRIPTION
Fix Admin password config

Add variables : 

- `DECIDIM_ADMIN_PASSWORD_STRONG`  default to `false` (`true` in decidim)
- `DECIDIM_ADMIN_PASSWORD_EXPIRATION_DAYS`  default to `365` (`90` indecidim)
- `DECIDIM_ADMIN_PASSWORD_REPETITION_TIMES`  default to `15`
- `DECIDIM_ADMIN_PASSWORD_MIN_LENGTH`  default to `5`
