### PR TITLE
hotfix: disable question captcha

### DIFF
--- a/config/initializers/decidim_questions.rb
+++ b/config/initializers/decidim_questions.rb
@@ -5,8 +5,12 @@ if defined?(Decidim::QuestionCaptcha)
     if Rails.application.secrets.question_captcha[:host].present?
       config.api_endpoint = "https://#{Rails.application.secrets.question_captcha[:host]}/"
     else
-      config.perform_textcaptcha = false
       Rails.logger.warn("You must define the env var 'QUESTION_CAPTCHA_HOST' to activate question captcha")
+    end
+
+    unless Rails.application.secrets.question_captcha[:enabled]
+      config.perform_textcaptcha = false
+      Rails.logger.warn("You must define the env var 'ENABLE_QUESTION_CAPTCHA' to activate question captcha")
     end
   end
 end

--- a/config/initializers/decidim_questions.rb
+++ b/config/initializers/decidim_questions.rb
@@ -1,11 +1,12 @@
 # frozen_string_literal: true
 
 if defined?(Decidim::QuestionCaptcha)
-  if Rails.application.secrets.question_captcha[:host].present?
-    Decidim::QuestionCaptcha.configure do |config|
+  Decidim::QuestionCaptcha.configure do |config|
+    if Rails.application.secrets.question_captcha[:host].present?
       config.api_endpoint = "https://#{Rails.application.secrets.question_captcha[:host]}/"
+    else
+      config.perform_textcaptcha = false
+      Rails.logger.warn("You must define the env var 'QUESTION_CAPTCHA_HOST' to activate question captcha")
     end
-  else
-    Rails.logger.warn("You must define the env var 'QUESTION_CAPTCHA_HOST' to activate question captcha")
   end
 end

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -91,6 +91,7 @@ default: &default
     api_key: <%= ENV["ETHERPAD_API_KEY"] %>
     api_version: "1.2.1"
   question_captcha:
+    enabled: <%= ENV.fetch("ENABLE_QUESTION_CAPTCHA", "1") == "1" %>
     host: <%= ENV["QUESTION_CAPTCHA_HOST"] %>
 development:
   <<: *default


### PR DESCRIPTION
#### :tophat: Description
*Please describe your pull request.*

Users can't sign up on platform because of question captcha inconsistency

#### :pushpin: Related Issues
*Link your PR to an issue*
- [Notion card](https://www.notion.so/opensourcepolitics/CD44-Unable-to-complete-the-captcha-when-registering-c714a1d2658f452ab8e10a75dda1012a?pvs=4)


#### Env var

We can disable Question captcha using
* `ENABLE_QUESTION_CAPTCHA=0`

By default CAPTCHA is enabled with '1'

