### PR TITLE
fix: Add missing data_authorization_handler form

### DIFF
--- a/app/views/data_authorization/_form.html.erb
+++ b/app/views/data_authorization/_form.html.erb
@@ -1,0 +1,51 @@
+<%= form.hidden_field :handler_name %>
+<div class="help-text help-text-form-required-fields">
+  * <%= t('decidim.authorization_handlers.data_authorization_handler.help_text.required_fields') %>
+</div>
+<div class="row">
+  <div class="columns medium-6">
+    <div class="field lastname_field">
+      <%= form.text_field :lastname, label: I18n.t('decidim.authorization_handlers.data_authorization_handler.fields.lastname')%>
+      <p class="help-text"><%= I18n.t('decidim.authorization_handlers.data_authorization_handler.help_text.lastname') %></p>
+    </div>
+  </div>
+  <div class="columns medium-6">
+    <div class="field firstname_field">
+      <%= form.text_field :firstname, label: I18n.t('decidim.authorization_handlers.data_authorization_handler.fields.firstname')%>
+      <p class="help-text"><%= I18n.t('decidim.authorization_handlers.data_authorization_handler.help_text.firstname') %></p>
+    </div>
+  </div>
+</div>
+<div class="row">
+  <div class="columns medium-4">
+    <div class="field postal_code_field">
+      <%= form.text_field :postal_code, label: I18n.t('decidim.authorization_handlers.data_authorization_handler.fields.postal_code'), maxlength: 5, pattern: "[0-9]{5}" %>
+      <p class="help-text"><%= I18n.t('decidim.authorization_handlers.data_authorization_handler.help_text.postal_code') %></p>
+    </div>
+  </div>
+  <div class="columns medium-8">
+    <div class="field city_field">
+      <%= form.text_field :city, label: I18n.t('decidim.authorization_handlers.data_authorization_handler.fields.city') %>
+      <p class="help-text"><%= I18n.t('decidim.authorization_handlers.data_authorization_handler.help_text.city') %></p>
+    </div>
+  </div>
+</div>
+<fieldset class="fieldset">
+  <legend class="legend"><%= I18n.t('decidim.authorization_handlers.data_authorization_handler.legend') %></legend>
+  <div class="row">
+    <div class="field phone_field columns medium-12">
+      <%= form.text_field :phone, label: I18n.t('decidim.authorization_handlers.data_authorization_handler.fields.phone') %>
+    </div>
+  </div>
+</fieldset>
+<div class="field gdpr_field">
+  <%= form.check_box :gdpr, label: I18n.t('decidim.authorization_handlers.data_authorization_handler.fields.gdpr') %>
+</div>
+<div class="field minimum_age_field">
+  <%= form.check_box :minimum_age, label: I18n.t('decidim.authorization_handlers.data_authorization_handler.fields.minimum_age') %>
+</div>
+<div class="padding-2">
+  <strong><%= I18n.t('decidim.authorization_handlers.data_authorization_handler.help_text.global_help')%></strong>
+</div>
+
+<%= javascript_pack_tag "extended_socio_demographic_authorization_handler" %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -48,6 +48,24 @@ en:
           gdpr: You must accept the terms and conditions
           minimum_age: You must be over 16 years old to register
           no_postal_code_result: No result found for this postal code
+        explanation: Verify your identity
+        fields:
+          city: City
+          firstname: Firstname
+          gdpr: I accept that my data will be used to verify my identity
+          lastname: Lastname
+          minimum_age: I confirm that I am over 16 years old
+          phone: Phone number
+          postal_code: Zip code
+        help_text:
+          city: Your city depends on your postal code, please select your city from the dropdown list
+          firstname: Your firstname must contain at least 1 character and be composed only of letters, spaces and special characters such as - and '
+          global_help: It is necessary to complete this form to submit a proposal in the participatory budget.
+          lastname: Your lastname must contain at least 1 character and be composed only of letters, spaces and special characters such as - and '
+          postal_code: Your postal code must be composed of 5 digits
+          required_fields: Required fields are marked with an asterisk
+        legend: Contact information
+        name: Data Sharing Process
       osp_authorization_handler:
         explanation: Vérifier votre identité en saisissant un numéro unique
         fields:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -48,6 +48,24 @@ fr:
           gdpr: Vous devez accepter les mentions légales
           minimum_age: Vous devez avoir plus de 16 ans pour pouvoir vous inscrire
           no_postal_code_result: Aucun résultat trouvé pour ce code postal
+        explanation: Vérifier votre identité
+        fields:
+          city: Ville
+          firstname: Prénom
+          gdpr: J'accepte la collecte de mes données personnelles pour l'instruction de mes propositions au budget participatif ou encore à des fins statistiques. Voir le détail du traitement réalisé sur les données à caractères personnelles dans le cadre du budget participatif
+          lastname: Nom
+          minimum_age: J'atteste avoir plus de 16 ans et résider, travailler ou étudier dans le département de Loire-Atlantique en complétant ce formulaire.
+          phone: Numéro de téléphone
+          postal_code: Code postal
+        help_text:
+          city: Votre ville dépend de votre code postal, veuillez sélectionner votre ville dans la liste déroulante
+          firstname: Votre prénom doit comporter au moins 1 caractère et n'être composé que de lettres, d'espaces et de caractères spéciaux tels que - et '
+          global_help: Il est nécessaire de compléter ce formulaire pour déposer une proposition dans le budget participatif
+          lastname: Votre nom doit comporter au moins 1 caractère et n'être composé que de lettres, d'espaces et de caractères spéciaux tels que - et '
+          postal_code: Votre code postal doit être composé de 5 chiffres
+          required_fields: Les champs obligatoires sont marqués d'un astérisque
+        legend: Informations de contact
+        name: Procédure de partage de données
       osp_authorization_handler:
         explanation: Vérifier votre identité en saisissant un numéro unique
         fields:

--- a/spec/system/data_authorization_spec.rb
+++ b/spec/system/data_authorization_spec.rb
@@ -1,0 +1,269 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe "Data authorization", type: :system do
+  let(:organization) { create(:organization, available_authorizations: ["data_authorization_handler"]) }
+  let(:user) { create(:user, :confirmed, organization: organization) }
+  let(:firstname) { "John" }
+  let(:lastname) { "Doe" }
+  let(:phone) { "0605040302" }
+  let(:postal_code) { "75001" }
+  let(:city) { "Paris 1er Arrondissement" }
+  let(:gdpr) { true }
+  let(:minimum_age) { true }
+  let(:response_body) do
+    JSON.dump([{ "75001" => "Paris 1er Arrondissement" }])
+  end
+  let(:stubbed_request) do
+    stub_request(:get, "/postal-code-autocomplete/75001").to_return(status: 200, body: response_body, headers: {})
+    stub_request(:get, "https://apicarto.ign.fr/api/codes-postaux/communes/75001").to_return(status: 200, body: response_body, headers: {})
+  end
+
+  before do
+    switch_to_host(organization.host)
+    login_as user, scope: :user
+    visit decidim_verifications.authorizations_path
+    click_link("Data Sharing Process")
+    stubbed_request
+  end
+
+  it "can be authorized" do
+    expect(page).to have_content("Data Sharing Process")
+  end
+
+  context "when the form is filled in correctly" do
+    before do
+      fill_in :authorization_handler_firstname, with: firstname
+      fill_in :authorization_handler_lastname, with: lastname
+      fill_in :authorization_handler_phone, with: phone
+      fill_in :authorization_handler_postal_code, with: postal_code
+      fill_in :authorization_handler_city, with: city
+      check :authorization_handler_gdpr
+      check :authorization_handler_minimum_age
+      click_button "Send"
+    end
+
+    shared_examples_for "is a valid firstname" do
+      it "is valid" do
+        expect(page).to have_content("successfully")
+      end
+    end
+
+    context "when the firstname is valid" do
+      let(:firstname) { "John" }
+
+      it_behaves_like "is a valid firstname"
+    end
+
+    context "when the firstname contains ' or -" do
+      let(:firstname) { "Jo-hn's" }
+
+      it_behaves_like "is a valid firstname"
+    end
+
+    context "when the firstname contains a space" do
+      let(:firstname) { "John Doe" }
+
+      it_behaves_like "is a valid firstname"
+    end
+
+    context "when the firstname contains an accent" do
+      let(:firstname) { "Jöhn Tâylot" }
+
+      it_behaves_like "is a valid firstname"
+    end
+
+    shared_examples_for "is a valid lastname" do
+      it "is valid" do
+        expect(page).to have_content("successfully")
+      end
+    end
+
+    context "when the lastname is valid" do
+      let(:lastname) { "Doe" }
+
+      it_behaves_like "is a valid lastname"
+    end
+
+    context "when the lastname contains ' or -" do
+      let(:lastname) { "Do-e's" }
+
+      it_behaves_like "is a valid lastname"
+    end
+
+    context "when the lastname contains a space" do
+      let(:lastname) { "Doe John" }
+
+      it_behaves_like "is a valid lastname"
+    end
+
+    context "when the lastname contains accents" do
+      let(:lastname) { "Maël-Taylôr" }
+
+      it_behaves_like "is a valid lastname"
+    end
+
+    it "authorizes the user" do
+      expect(page).to have_content("successfully")
+    end
+  end
+
+  context "when the form is filled in incorrectly" do
+    before do
+      fill_in :authorization_handler_firstname, with: firstname
+      fill_in :authorization_handler_lastname, with: lastname
+      fill_in :authorization_handler_phone, with: phone
+      fill_in :authorization_handler_postal_code, with: postal_code
+      fill_in :authorization_handler_city, with: city
+      check :authorization_handler_gdpr
+      check :authorization_handler_minimum_age
+    end
+
+    shared_examples_for "is an invalid firstname" do
+      it "is invalid" do
+        expect(page).to have_content("contains an error")
+      end
+    end
+
+    context "when the firstname contains number" do
+      let(:firstname) { "John1" }
+
+      before do
+        click_button "Send"
+      end
+
+      it_behaves_like "is an invalid firstname"
+    end
+
+    context "when the firstname contains special characters" do
+      let(:firstname) { "John@" }
+
+      before do
+        click_button "Send"
+      end
+
+      it_behaves_like "is an invalid firstname"
+    end
+
+    shared_examples_for "is an invalid lastname" do
+      it "is invalid" do
+        expect(page).to have_content("contains an error")
+      end
+    end
+
+    context "when the lastname contains number" do
+      let(:lastname) { "Doe1" }
+
+      before do
+        click_button "Send"
+      end
+
+      it_behaves_like "is an invalid lastname"
+    end
+
+    context "when the lastname contains special characters" do
+      let(:lastname) { "Doe@" }
+
+      before do
+        click_button "Send"
+      end
+
+      it_behaves_like "is an invalid lastname"
+    end
+
+    describe "when the name is empty" do
+      let(:lastname) { "" }
+
+      before do
+        click_button "Send"
+      end
+
+      it "does not authorize the user" do
+        expect(page).to have_content("error")
+      end
+    end
+
+    describe "when the firstname is empty" do
+      let(:firstname) { "" }
+
+      before do
+        click_button "Send"
+      end
+
+      it "does not authorize the user" do
+        expect(page).to have_content("error")
+      end
+    end
+
+    describe "when the phone number is empty" do
+      let(:phone) { "" }
+
+      before do
+        click_button "Send"
+      end
+
+      it "does not authorize the user" do
+        expect(page).to have_content("error")
+      end
+    end
+
+    describe "when no postal code is entered" do
+      let(:postal_code) { "" }
+
+      before do
+        click_button "Send"
+      end
+
+      it "does not authorize the user" do
+        expect(page).to have_content("error")
+      end
+    end
+
+    describe "when the postal_code is invalid" do
+      let(:postal_code) { "1234" }
+
+      before do
+        click_button "Send"
+      end
+
+      it "does not authorize the user" do
+        expect(page).to have_content("error")
+      end
+    end
+
+    describe "when the city is empty" do
+      let(:city) { "" }
+
+      before do
+        click_button "Send"
+      end
+
+      it "does not authorize the user" do
+        expect(page).to have_content("error")
+      end
+    end
+
+    describe "when gdpr is not checked" do
+      before do
+        uncheck :authorization_handler_gdpr
+        click_button "Send"
+      end
+
+      it "does not authorize the user" do
+        expect(page).to have_content("must be accepted")
+      end
+    end
+
+    describe "when minimum age is not checked" do
+      before do
+        uncheck :authorization_handler_minimum_age
+        click_button "Send"
+      end
+
+      it "does not authorize the user" do
+        expect(page).to have_content("must be accepted")
+      end
+    end
+  end
+end


### PR DESCRIPTION
#### :tophat: Description
This PR is supposed to fix the disappearance of the Data Authorization Handler from CD44 which was a customization we did for the client but that we removed unexpectedly.

#### :pushpin: Related Issues
- [Notion card](https://www.notion.so/opensourcepolitics/CD44-Missing-translations-Data-AH-first-login-AH-225c7ce87f794dd48084a45d3bcbde46?pvs=4)

#### Testing
*Describe the best way to test or validate your PR.*

Example:
* Log in as admin
* Go to Profile
* Go to Authorizations
* Click on "Data Sharing Process"
* Complete the Form
* Check that everything went good

#### Tasks
- [x] Add specs
- [x] Add form
