### PR TITLE
release: Bump friendly signup and fix budget projects filter

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -76,7 +76,7 @@ jobs:
         if: "github.ref != 'refs/heads/master' || github.ref != 'refs/heads/develop'"
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
-      - uses: OpenSourcePolitics/rspec-action@master
+      - uses: OpenSourcePolitics/rspec-action@fix/chromedriver_lock_119
         with:
           command: 'bundle exec rspec --exclude-pattern "spec/system/**/*_spec.rb"'
           prepare_command: "bundle exec rails db:create db:migrate"
@@ -106,7 +106,7 @@ jobs:
         if: "github.ref != 'refs/heads/master' || github.ref != 'refs/heads/develop'"
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
-      - uses: OpenSourcePolitics/rspec-action@master
+      - uses: OpenSourcePolitics/rspec-action@fix/chromedriver_lock_119
         with:
           command: 'bundle exec rspec "spec/system"'
           prepare_command: "bundle exec rails db:create db:migrate"

--- a/Gemfile
+++ b/Gemfile
@@ -21,7 +21,7 @@ gem "decidim-cache_cleaner"
 gem "decidim-decidim_awesome", "~> 0.9.1"
 gem "decidim-extended_socio_demographic_authorization_handler", git: "https://github.com/OpenSourcePolitics/decidim-module-extended_socio_demographic_authorization_handler",
                                                                 branch: DECIDIM_BRANCH
-gem "decidim-friendly_signup", git: "https://github.com/OpenSourcePolitics/decidim-module-friendly_signup", branch: "fast_sign_up_management"
+gem "decidim-friendly_signup", git: "https://github.com/OpenSourcePolitics/decidim-module-friendly_signup", branch: "bump/fast_sign_up_branch"
 gem "decidim-question_captcha", git: "https://github.com/OpenSourcePolitics/decidim-module-question_captcha.git", branch: DECIDIM_BRANCH
 gem "decidim-simple_proposal", git: "https://github.com/opensourcepolitics/decidim-module-simple_proposal.git", branch: "fix/0.27_scope_picker_override"
 gem "decidim-spam_detection", "4.0.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -15,10 +15,10 @@ GIT
 
 GIT
   remote: https://github.com/OpenSourcePolitics/decidim-module-friendly_signup
-  revision: cf4ee3f57fecd291fe896f711c53593148f501bb
-  branch: fast_sign_up_management
+  revision: e3f7843b1d5ebc1cc68a4bfaadfe36e7c2a0c37f
+  branch: bump/fast_sign_up_branch
   specs:
-    decidim-friendly_signup (0.4.4)
+    decidim-friendly_signup (0.4.5)
       decidim-core (~> 0.27)
 
 GIT

--- a/config/application.rb
+++ b/config/application.rb
@@ -49,6 +49,7 @@ module DevelopmentApp
     config.after_initialize do
       require "extends/controllers/decidim/devise/sessions_controller_extends"
       require "extends/controllers/decidim/editor_images_controller_extends"
+      require "extends/models/decidim/budgets/project_extend"
       require "extends/services/decidim/iframe_disabler_extends"
 
       Decidim::GraphiQL::Rails.config.tap do |config|

--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -35,11 +35,15 @@ services:
       - SEED=true
       - DEFACE_ENABLED=false
       - QUESTION_CAPTCHA_HOST=
-      - DECIDIM_SESSION_TIMEOUT=30
+      - ENABLE_RACK_ATTACK=0
+      - PUMA_MIN_THREADS=5
+      - PUMA_MAX_THREADS=5
+      - PUMA_WORKERS=4
+      - PUMA_PRELOAD_APP=true
     depends_on:
       - app
     volumes:
-      - .:/app
+      - shared-volume:/app
     links:
       - database
       - redis
@@ -61,9 +65,13 @@ services:
       - SEED=true
       - DEFACE_ENABLED=false
       - QUESTION_CAPTCHA_HOST=
-      - DECIDIM_SESSION_TIMEOUT=30
+      - ENABLE_RACK_ATTACK=0
+      - PUMA_MIN_THREADS=5
+      - PUMA_MAX_THREADS=5
+      - PUMA_WORKERS=4
+      - PUMA_PRELOAD_APP=true
     volumes:
-      - .:/app
+      - shared-volume:/app
     ports:
       - 3000:3000
     depends_on:
@@ -72,6 +80,6 @@ services:
       - memcached
 
 volumes:
-  app-data: { }
+  shared-volume: { }
   pg-data: { }
   redis-data: { }

--- a/lib/extends/models/decidim/budgets/project_extend.rb
+++ b/lib/extends/models/decidim/budgets/project_extend.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require "active_support/concern"
+module ProjectExtends
+  extend ActiveSupport::Concern
+
+  included do
+    def self.ordered_ids(ids)
+      # Make sure each ID in the matching text has a "," character as their
+      # delimiter. Otherwise e.g. ID 2 would match ID "26" in the original
+      # array. This is why we search for match ",2," instead to get the actual
+      # position for ID 2.
+      concat_ids = connection.quote(",#{ids.join(",")},")
+      order(Arel.sql("position(concat(',', decidim_budgets_projects.id::text, ',') in #{concat_ids})"))
+    end
+  end
+end
+
+Decidim::Budgets::Project.include(ProjectExtends)

--- a/spec/models/decidim/budgets/project_spec.rb
+++ b/spec/models/decidim/budgets/project_spec.rb
@@ -1,0 +1,113 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim::Budgets
+  describe Project do
+    subject { project }
+
+    let(:project) { create(:project) }
+
+    include_examples "has reference"
+    include_examples "resourceable"
+
+    it { is_expected.to be_valid }
+    it { is_expected.to be_versioned }
+
+    context "without a budget" do
+      let(:project) { build(:project, budget: nil) }
+
+      it { is_expected.not_to be_valid }
+    end
+
+    context "when the scope is from another organization" do
+      let(:scope) { create(:scope) }
+      let(:project) { build(:project, scope: scope) }
+
+      it { is_expected.not_to be_valid }
+    end
+
+    context "when the category is from another organization" do
+      let(:category) { create(:category) }
+      let(:project) { build(:project, category: category) }
+
+      it { is_expected.not_to be_valid }
+    end
+
+    describe ".ordered_ids" do
+      let(:budget) { create(:budget, total_budget: 1_000_000) }
+      let(:category) { create(:category, participatory_space: budget.participatory_space) }
+      let(:projects) { create_list(:project, 50, budget: budget, budget_amount: 100_000, category: category) }
+      let(:test_ids) do
+        first = described_class.where(budget: budget).order(:id).pluck(:id)[0..3]
+        ids = described_class.where(budget: budget).pluck(:id).shuffle
+
+        # Put the first items at the end of the IDs array in order to get
+        # possibly "conflicting" matches for them at earlier array positions.
+        # As we have 50 projects, we should have IDs starting with 1, 2, 3 and 4
+        # which is why we put the first 4 items at the end.
+        (ids - first) + first
+      end
+
+      before do
+        # Reset the project IDs to start from 1 in order to get possibly
+        # "conflicting" ID sequences for the `.ordered_ids` call. In the past,
+        # e.g. IDs such as "2", and "23" (containing "2") would have caused the
+        # wrong order in case "23" comes first in the ordered IDs list.
+        ActiveRecord::Base.connection.reset_pk_sequence!(described_class.table_name)
+
+        # Create the projects after the sequence has been reset
+        projects
+      end
+
+      it "returns the correctly ordered projects" do
+        expect(described_class.ordered_ids(test_ids).pluck(:id)).to eq(test_ids)
+      end
+
+      it "returns the correctly ordered projects after filtering by category" do
+        expect(described_class.with_any_category([category.id]).ordered_ids(test_ids).pluck(:id)).to eq(test_ids)
+      end
+    end
+
+    describe "#orders_count" do
+      let(:project) { create(:project, budget_amount: 75_000_000) }
+      let(:order) { create(:order, budget: project.budget) }
+      let(:unfinished_order) { create(:order, budget: project.budget) }
+      let!(:line_item) { create(:line_item, project: project, order: order) }
+      let!(:line_item1) { create(:line_item, project: project, order: unfinished_order) }
+
+      it "return number of finished orders for this project" do
+        order.reload.update!(checked_out_at: Time.current)
+        expect(project.confirmed_orders_count).to eq(1)
+      end
+    end
+
+    describe "#users_to_notify_on_comment_created" do
+      let!(:follows) { create_list(:follow, 3, followable: subject) }
+
+      it "returns the followers" do
+        expect(subject.users_to_notify_on_comment_created).to match_array(follows.map(&:user))
+      end
+    end
+
+    describe "#selected?" do
+      let(:project) { create(:project, selected_at: selected_at) }
+
+      context "when selected_at is blank" do
+        let(:selected_at) { nil }
+
+        it "returns true" do
+          expect(project.selected?).to be false
+        end
+      end
+
+      context "when selected_at is present" do
+        let(:selected_at) { Time.current }
+
+        it "returns true" do
+          expect(project.selected?).to be true
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
#### :tophat: Description
Bump decidim-friendly_signup module's branch and fix projects filters in Budgets

#### :pushpin: Related Issues
- Related to #148 and #149 

#### Testing
To test #149 :

- Go to budgets projects (the vote counter must be displayed)
- Try to filter and sort projects
- You should not have 500 error 
